### PR TITLE
Preferences Modal UI

### DIFF
--- a/frontend/locales/en/common.json
+++ b/frontend/locales/en/common.json
@@ -1,4 +1,6 @@
 {
   "test": "test",
-  "title": "Smart Ryokou"
+  "title": "Smart Ryokou",
+  "cancel": "Cancel",
+  "finish": "Finish"
 }

--- a/frontend/locales/en/home.json
+++ b/frontend/locales/en/home.json
@@ -1,3 +1,5 @@
 {
-  "input-message": "Search for the place you want to go!"
+  "input-message": "Search for the place you want to go!",
+  "dialog-title": "Your trip in",
+  "dialog-content": "Select your travel preferences"
 }

--- a/frontend/locales/en/home.json
+++ b/frontend/locales/en/home.json
@@ -5,6 +5,7 @@
   "date-label": "Desired date",
   "date-from-label": "Date from",
   "date-until-label": "Date until",
+  "people-number-label": "Number of people",
   "trip-type-label": "Trip type",
   "trip-type": {
     "solo": "Solo",

--- a/frontend/locales/en/home.json
+++ b/frontend/locales/en/home.json
@@ -1,5 +1,52 @@
 {
   "input-message": "Search for the place you want to go!",
   "dialog-title": "Your trip in",
-  "dialog-content": "Select your travel preferences"
+  "dialog-content": "Select your travel preferences",
+  "date-label": "Desired date",
+  "date-from-label": "Date from",
+  "date-until-label": "Date until",
+  "trip-type-label": "Trip type",
+  "trip-type": {
+    "solo": "Solo",
+    "couple": "Couple",
+    "family": "Family",
+    "friends": "Friends",
+    "business": "Business",
+    "backpacker": "Backpacker"
+  },
+  "pace-label": "Pace",
+  "pace": {
+    "relaxed": "Relaxed",
+    "normal": "Normal",
+    "packed": "Packed"
+  },
+  "budget-label": "Budget",
+  "budget": {
+    "low": "Budget",
+    "medium": "Moderate",
+    "high": "Luxury"
+  },
+  "interests-label": "Interests",
+  "interests": {
+    "food": "Food",
+    "nature": "Nature",
+    "shopping": "Shopping",
+    "sports": "Sports",
+    "culture": "Culture",
+    "art": "Art",
+    "history": "History",
+    "museum": "Museum",
+    "adventure": "Adventure",
+    "sightseeing": "Sightseeing",
+    "festival": "Festival",
+    "party": "Party",
+    "photo": "Photo",
+    "beach": "Beach",
+    "mountain": "Mountain",
+    "temple": "Temple",
+    "park": "Park",
+    "zoo": "Zoo",
+    "aquarium": "Aquarium",
+    "amusement": "Amusement"
+  }
 }

--- a/frontend/locales/ja/common.json
+++ b/frontend/locales/ja/common.json
@@ -1,4 +1,6 @@
 {
   "test": "テスト",
-  "title": "Smart旅行"
+  "title": "Smart旅行",
+  "cancel": "閉じる",
+  "finish": "完了"
 }

--- a/frontend/locales/ja/home.json
+++ b/frontend/locales/ja/home.json
@@ -1,7 +1,7 @@
 {
   "input-message": "場所を検索する！",
-  "dialog-title": "でのトリップ",
-  "dialog-content": "トリップの好みを選択してください",
+  "dialog-title": "での旅行計画",
+  "dialog-content": "旅行の好みを選択してください",
   "date-label": "日程",
   "date-from-label": "から",
   "date-until-label": "まで",

--- a/frontend/locales/ja/home.json
+++ b/frontend/locales/ja/home.json
@@ -1,3 +1,5 @@
 {
-  "input-message": "場所を検索する！"
+  "input-message": "場所を検索する！",
+  "dialog-title": "でのトリップ",
+  "dialog-content": "トリップの好みを選択してください"
 }

--- a/frontend/locales/ja/home.json
+++ b/frontend/locales/ja/home.json
@@ -1,5 +1,52 @@
 {
   "input-message": "場所を検索する！",
   "dialog-title": "でのトリップ",
-  "dialog-content": "トリップの好みを選択してください"
+  "dialog-content": "トリップの好みを選択してください",
+  "date-label": "日程",
+  "date-from-label": "から",
+  "date-until-label": "まで",
+  "trip-type-label": "旅行種類",
+  "trip-type": {
+    "solo": "一人",
+    "couple": "カップル",
+    "family": "家族",
+    "friends": "友達",
+    "business": "ビジネス",
+    "backpacker": "バックパッカー"
+  },
+  "pace-label": "ペース",
+  "pace": {
+    "relaxed": "ゆっくり",
+    "normal": "普通",
+    "packed": "せっかち"
+  },
+  "budget-label": "予算",
+  "budget": {
+    "low": "安い",
+    "medium": "普通",
+    "high": "高級"
+  },
+  "interests-label": "興味",
+  "interests": {
+    "food": "グルメ",
+    "nature": "自然",
+    "shopping": "買い物",
+    "sports": "スポーツ",
+    "culture": "文化",
+    "art": "芸術",
+    "history": "歴史",
+    "museum": "博物館",
+    "adventure": "アドベンチャー",
+    "sightseeing": "観光",
+    "festival": "お祭り",
+    "party": "パーティー",
+    "photo": "写真",
+    "beach": "海",
+    "mountain": "山",
+    "temple": "お寺・神社",
+    "park": "公園",
+    "zoo": "動物園",
+    "aquarium": "水族館",
+    "amusement": "遊園地"
+  }
 }

--- a/frontend/locales/ja/home.json
+++ b/frontend/locales/ja/home.json
@@ -5,6 +5,7 @@
   "date-label": "日程",
   "date-from-label": "から",
   "date-until-label": "まで",
+  "people-number-label": "人数",
   "trip-type-label": "旅行種類",
   "trip-type": {
     "solo": "一人",
@@ -14,17 +15,17 @@
     "business": "ビジネス",
     "backpacker": "バックパッカー"
   },
-  "pace-label": "ペース",
+  "pace-label": "旅行ペース",
   "pace": {
     "relaxed": "ゆっくり",
     "normal": "普通",
-    "packed": "せっかち"
+    "packed": "早い"
   },
   "budget-label": "予算",
   "budget": {
-    "low": "安い",
+    "low": "少なめ",
     "medium": "普通",
-    "high": "高級"
+    "high": "多め"
   },
   "interests-label": "興味",
   "interests": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,8 @@
         "@emotion/styled": "^11.11.0",
         "@mui/icons-material": "^5.14.3",
         "@mui/material": "^5.14.5",
+        "@mui/x-date-pickers": "^6.15.0",
+        "moment": "^2.29.4",
         "next": "13.4.16",
         "next-translate": "^2.5.3",
         "react": "18.2.0",
@@ -245,9 +247,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.10.tgz",
-      "integrity": "sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.15.tgz",
+      "integrity": "sha512-T0O+aa+4w0u06iNmapipJXMV4HoUir03hpx3/YqXXhu9xim3w+dVphjFWl1OH8NbZHw5Lbm9k45drDkgq2VNNA==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -456,6 +458,40 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.5.0.tgz",
+      "integrity": "sha512-kK1h4m36DQ0UHGj5Ah4db7R0rHemTqqO0QLvUqi1/mUUp3LuAWbWxdxSIf/XsnH9VS6rRVPLJCncjRzUvyCLXg==",
+      "dependencies": {
+        "@floating-ui/utils": "^0.1.3"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.3.tgz",
+      "integrity": "sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==",
+      "dependencies": {
+        "@floating-ui/core": "^1.4.2",
+        "@floating-ui/utils": "^0.1.3"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.2.tgz",
+      "integrity": "sha512-5qhlDvjaLmAst/rKb3VdlCinwTF4EYMiVxuuc/HVUjs46W0zgtbMmAZ1UTsDrRTxRmUEzl92mOtWbeeXL26lSQ==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.5.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.4.tgz",
+      "integrity": "sha512-qprfWkn82Iw821mcKofJ5Pk9wgioHicxcQMxx+5zt5GSKoqdWvgG5AxVmpmUUjzTLPVSH5auBrhI93Deayn/DA=="
     },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
@@ -733,13 +769,12 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "5.14.5",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.14.5.tgz",
-      "integrity": "sha512-6Hzw63VR9C5xYv+CbjndoRLU6Gntal8rJ5W+GUzkyHrGWIyYPWZPa6AevnyGioySNETATe1H9oXS8f/7qgIHJA==",
+      "version": "5.14.10",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.14.10.tgz",
+      "integrity": "sha512-Rn+vYQX7FxkcW0riDX/clNUwKuOJFH45HiULxwmpgnzQoQr3A0lb+QYwaZ+FAkZrR7qLoHKmLQlcItu6LT0y/Q==",
       "dependencies": {
-        "@babel/runtime": "^7.22.6",
+        "@babel/runtime": "^7.22.15",
         "@types/prop-types": "^15.7.5",
-        "@types/react-is": "^18.2.1",
         "prop-types": "^15.8.1",
         "react-is": "^18.2.0"
       },
@@ -751,13 +786,115 @@
         "url": "https://opencollective.com/mui"
       },
       "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0",
         "react": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@mui/utils/node_modules/react-is": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
+    "node_modules/@mui/x-date-pickers": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-6.15.0.tgz",
+      "integrity": "sha512-ubo5SBGe5qPU3F7/mMOa/Yb52GggLGvROCe3HdlatD6LebsxqsERsI2O8aLqwUwIb1AAX2GeiJLdvNBPCQ8xpQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.15",
+        "@mui/base": "^5.0.0-beta.14",
+        "@mui/utils": "^5.14.8",
+        "@types/react-transition-group": "^4.4.6",
+        "clsx": "^2.0.0",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.9.0",
+        "@emotion/styled": "^11.8.1",
+        "@mui/material": "^5.8.6",
+        "@mui/system": "^5.8.0",
+        "date-fns": "^2.25.0",
+        "date-fns-jalali": "^2.13.0-0",
+        "dayjs": "^1.10.7",
+        "luxon": "^3.0.2",
+        "moment": "^2.29.4",
+        "moment-hijri": "^2.1.2",
+        "moment-jalaali": "^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "date-fns": {
+          "optional": true
+        },
+        "date-fns-jalali": {
+          "optional": true
+        },
+        "dayjs": {
+          "optional": true
+        },
+        "luxon": {
+          "optional": true
+        },
+        "moment": {
+          "optional": true
+        },
+        "moment-hijri": {
+          "optional": true
+        },
+        "moment-jalaali": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/x-date-pickers/node_modules/@mui/base": {
+      "version": "5.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.16.tgz",
+      "integrity": "sha512-OYxhC81c9bO0wobGcM8rrY5bRwpCXAI21BL0P2wz/2vTv4ek7ALz9+U5M8wgdmtRNUhmCmAB4L2WRwFRf5Cd8Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.15",
+        "@floating-ui/react-dom": "^2.0.2",
+        "@mui/types": "^7.2.4",
+        "@mui/utils": "^5.14.10",
+        "@popperjs/core": "^2.11.8",
+        "clsx": "^2.0.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@next/env": {
       "version": "13.4.16",
@@ -1035,14 +1172,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.7.tgz",
       "integrity": "sha512-GRaAEriuT4zp9N4p1i8BDBYmEyfo+xQ3yHjJU4eiK5NDa1RmUZG+unZABUTK4/Ox/M+GaHwb6Ow8rUITrtjszA==",
       "dev": true,
-      "dependencies": {
-        "@types/react": "*"
-      }
-    },
-    "node_modules/@types/react-is": {
-      "version": "18.2.1",
-      "resolved": "https://registry.npmjs.org/@types/react-is/-/react-is-18.2.1.tgz",
-      "integrity": "sha512-wyUkmaaSZEzFZivD8F2ftSyAfk6L+DfFliVj/mYdOXbVjRcS87fQJLTnhk6dRZPuJjI+9g6RZJO4PNCngUrmyw==",
       "dependencies": {
         "@types/react": "*"
       }
@@ -3305,6 +3434,14 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ms": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,8 @@
     "@emotion/styled": "^11.11.0",
     "@mui/icons-material": "^5.14.3",
     "@mui/material": "^5.14.5",
+    "@mui/x-date-pickers": "^6.15.0",
+    "moment": "^2.29.4",
     "next": "13.4.16",
     "next-translate": "^2.5.3",
     "react": "18.2.0",

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,4 +1,4 @@
-import InputBar from '@/components/prompt/InputBar';
+import Prompt from '@/components/prompt/Prompt';
 import { Box, Container, Typography } from '@mui/material';
 import createTranslation from 'next-translate/useTranslation';
 
@@ -18,7 +18,7 @@ const Home = async () => {
         <Typography variant="h1" component="h1">
           {t('title')}
         </Typography>
-        <InputBar />
+        <Prompt />
       </Box>
     </Container>
   );

--- a/frontend/src/components/prompt/InputBar.tsx
+++ b/frontend/src/components/prompt/InputBar.tsx
@@ -33,6 +33,7 @@ const InputBar = ({ placeInput, setPlaceInput, handleOpenModal }: Props) => {
     >
       <TextField
         fullWidth
+        required
         id="search"
         type="search"
         placeholder={t('input-message')}

--- a/frontend/src/components/prompt/InputBar.tsx
+++ b/frontend/src/components/prompt/InputBar.tsx
@@ -1,16 +1,26 @@
 'use client';
 
-import { useState } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
 import { InputAdornment, TextField } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
 import useTranslation from 'next-translate/useTranslation';
 
-const InputBar = () => {
-  const [input, setInput] = useState('');
+type Props = {
+  placeInput: string;
+  setPlaceInput: Dispatch<SetStateAction<string>>;
+  handleOpenModal: () => void;
+};
+
+const InputBar = ({ placeInput, setPlaceInput, handleOpenModal }: Props) => {
   const { t } = useTranslation('home');
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setInput(event.target.value);
+    setPlaceInput(event.target.value);
+  };
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    handleOpenModal();
   };
 
   return (
@@ -19,13 +29,14 @@ const InputBar = () => {
         padding: 20,
         width: '600px',
       }}
+      onSubmit={handleSubmit}
     >
       <TextField
         fullWidth
         id="search"
         type="search"
         placeholder={t('input-message')}
-        value={input}
+        value={placeInput}
         onChange={handleChange}
         InputProps={{
           endAdornment: (

--- a/frontend/src/components/prompt/PreferencesModal.tsx
+++ b/frontend/src/components/prompt/PreferencesModal.tsx
@@ -8,6 +8,12 @@ import {
   DialogActions,
   Button,
 } from '@mui/material';
+import { usePreferences } from '@/hooks/usePreferences';
+import TripTypeForm from '@/components/prompt/form/TripTypeForm';
+import DateRangeForm from '@/components/prompt/form/DateRangeForm';
+import PaceForm from '@/components/prompt/form/PaceForm';
+import BudgetForm from '@/components/prompt/form/BudgetForm';
+import InterestsForm from '@/components/prompt/form/InterestsForm';
 import createTranslation from 'next-translate/useTranslation';
 
 type Props = {
@@ -17,6 +23,17 @@ type Props = {
 };
 
 const PreferencesModal = ({ placeInput, openModal, handleCloseModal }: Props) => {
+  const {
+    selectedTripType,
+    handleSelectTripType,
+    selectedPace,
+    handleSelectPace,
+    selectedBudget,
+    handleSelectBudget,
+    selectedInterests,
+    handleSelectInterest,
+  } = usePreferences();
+
   const homeT = createTranslation('home');
   const commonT = createTranslation('common');
 
@@ -31,8 +48,19 @@ const PreferencesModal = ({ placeInput, openModal, handleCloseModal }: Props) =>
           ? `${placeInput}${ht('dialog-title')}`
           : `${ht('dialog-title')} ${placeInput}`}
       </DialogTitle>
-      <DialogContent>
+      <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
         <DialogContentText>{ht('dialog-content')}</DialogContentText>
+        <DateRangeForm />
+        <TripTypeForm
+          selectedTripTypes={selectedTripType}
+          handleSelectTripType={handleSelectTripType}
+        />
+        <PaceForm selectedPace={selectedPace} handleSelectPace={handleSelectPace} />
+        <BudgetForm selectedBudget={selectedBudget} handleSelectBudget={handleSelectBudget} />
+        <InterestsForm
+          selectedInterests={selectedInterests}
+          handleSelectInterest={handleSelectInterest}
+        />
       </DialogContent>
       <DialogActions>
         <Button onClick={handleCloseModal}>{ct('cancel')}</Button>

--- a/frontend/src/components/prompt/PreferencesModal.tsx
+++ b/frontend/src/components/prompt/PreferencesModal.tsx
@@ -20,19 +20,23 @@ const PreferencesModal = ({ placeInput, openModal, handleCloseModal }: Props) =>
   const homeT = createTranslation('home');
   const commonT = createTranslation('common');
 
+  const lang = homeT.lang;
+  const ht = homeT.t;
+  const ct = commonT.t;
+
   return (
     <Dialog open={openModal} onClose={handleCloseModal}>
       <DialogTitle>
-        {homeT.lang === 'ja'
-          ? `${placeInput}${homeT.t('dialog-title')}`
-          : `${homeT.t('dialog-title')} ${placeInput}`}
+        {lang === 'ja'
+          ? `${placeInput}${ht('dialog-title')}`
+          : `${ht('dialog-title')} ${placeInput}`}
       </DialogTitle>
       <DialogContent>
-        <DialogContentText>{homeT.t('dialog-content')}</DialogContentText>
+        <DialogContentText>{ht('dialog-content')}</DialogContentText>
       </DialogContent>
       <DialogActions>
-        <Button onClick={handleCloseModal}>{commonT.t('cancel')}</Button>
-        <Button onClick={handleCloseModal}>{commonT.t('finish')}</Button>
+        <Button onClick={handleCloseModal}>{ct('cancel')}</Button>
+        <Button onClick={handleCloseModal}>{ct('finish')}</Button>
       </DialogActions>
     </Dialog>
   );

--- a/frontend/src/components/prompt/PreferencesModal.tsx
+++ b/frontend/src/components/prompt/PreferencesModal.tsx
@@ -24,6 +24,10 @@ type Props = {
 
 const PreferencesModal = ({ placeInput, openModal, handleCloseModal }: Props) => {
   const {
+    fromDate,
+    handleFromDateChange,
+    toDate,
+    handleToDateChange,
     selectedTripType,
     handleSelectTripType,
     selectedPace,
@@ -50,7 +54,12 @@ const PreferencesModal = ({ placeInput, openModal, handleCloseModal }: Props) =>
       </DialogTitle>
       <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
         <DialogContentText>{ht('dialog-content')}</DialogContentText>
-        <DateRangeForm />
+        <DateRangeForm
+          fromDate={fromDate}
+          handleFromDateChange={handleFromDateChange}
+          toDate={toDate}
+          handleToDateChange={handleToDateChange}
+        />
         <TripTypeForm
           selectedTripTypes={selectedTripType}
           handleSelectTripType={handleSelectTripType}

--- a/frontend/src/components/prompt/PreferencesModal.tsx
+++ b/frontend/src/components/prompt/PreferencesModal.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+  Button,
+} from '@mui/material';
+import createTranslation from 'next-translate/useTranslation';
+
+type Props = {
+  placeInput: string;
+  openModal: boolean;
+  handleCloseModal: () => void;
+};
+
+const PreferencesModal = ({ placeInput, openModal, handleCloseModal }: Props) => {
+  const homeT = createTranslation('home');
+  const commonT = createTranslation('common');
+
+  return (
+    <Dialog open={openModal} onClose={handleCloseModal}>
+      <DialogTitle>
+        {homeT.lang === 'ja'
+          ? `${placeInput}${homeT.t('dialog-title')}`
+          : `${homeT.t('dialog-title')} ${placeInput}`}
+      </DialogTitle>
+      <DialogContent>
+        <DialogContentText>{homeT.t('dialog-content')}</DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleCloseModal}>{commonT.t('cancel')}</Button>
+        <Button onClick={handleCloseModal}>{commonT.t('finish')}</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default PreferencesModal;

--- a/frontend/src/components/prompt/PreferencesModal.tsx
+++ b/frontend/src/components/prompt/PreferencesModal.tsx
@@ -11,6 +11,7 @@ import {
 import { usePreferences } from '@/hooks/usePreferences';
 import TripTypeForm from '@/components/prompt/form/TripTypeForm';
 import DateRangeForm from '@/components/prompt/form/DateRangeForm';
+import PeopleNumberForm from '@/components/prompt/form/PeopleNumberForm';
 import PaceForm from '@/components/prompt/form/PaceForm';
 import BudgetForm from '@/components/prompt/form/BudgetForm';
 import InterestsForm from '@/components/prompt/form/InterestsForm';
@@ -28,6 +29,8 @@ const PreferencesModal = ({ placeInput, openModal, handleCloseModal }: Props) =>
     handleFromDateChange,
     toDate,
     handleToDateChange,
+    peopleNumber,
+    handlePeopleNumberChange,
     selectedTripType,
     handleSelectTripType,
     selectedPace,
@@ -59,6 +62,10 @@ const PreferencesModal = ({ placeInput, openModal, handleCloseModal }: Props) =>
           handleFromDateChange={handleFromDateChange}
           toDate={toDate}
           handleToDateChange={handleToDateChange}
+        />
+        <PeopleNumberForm
+          peopleNumber={peopleNumber}
+          handlePeopleNumberChange={handlePeopleNumberChange}
         />
         <TripTypeForm
           selectedTripTypes={selectedTripType}

--- a/frontend/src/components/prompt/PreferencesModal.tsx
+++ b/frontend/src/components/prompt/PreferencesModal.tsx
@@ -71,9 +71,11 @@ const PreferencesModal = ({ placeInput, openModal, handleCloseModal }: Props) =>
           handleSelectInterest={handleSelectInterest}
         />
       </DialogContent>
-      <DialogActions>
+      <DialogActions sx={{ margin: 3 }}>
         <Button onClick={handleCloseModal}>{ct('cancel')}</Button>
-        <Button onClick={handleCloseModal}>{ct('finish')}</Button>
+        <Button onClick={handleCloseModal} variant="contained">
+          {ct('finish')}
+        </Button>
       </DialogActions>
     </Dialog>
   );

--- a/frontend/src/components/prompt/Prompt.tsx
+++ b/frontend/src/components/prompt/Prompt.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useState } from 'react';
+import InputBar from '@/components/prompt/InputBar';
+import PreferencesModal from '@/components/prompt/PreferencesModal';
+
+const Prompt = () => {
+  const [openModal, setOpenModal] = useState(false);
+  const [placeInput, setPlaceInput] = useState('');
+
+  const handleOpenModal = () => {
+    setOpenModal(true);
+  };
+
+  const handleCloseModal = () => {
+    setOpenModal(false);
+  };
+
+  return (
+    <>
+      <InputBar
+        placeInput={placeInput}
+        setPlaceInput={setPlaceInput}
+        handleOpenModal={handleOpenModal}
+      />
+      <PreferencesModal
+        placeInput={placeInput}
+        openModal={openModal}
+        handleCloseModal={handleCloseModal}
+      />
+    </>
+  );
+};
+
+export default Prompt;

--- a/frontend/src/components/prompt/form/BudgetForm.tsx
+++ b/frontend/src/components/prompt/form/BudgetForm.tsx
@@ -10,13 +10,21 @@ type Props = {
 const PaceForm = ({ selectedBudget, handleSelectBudget }: Props) => {
   const { t } = createTranslation('home');
 
+  const budgets = [
+    { label: t('budget.low'), value: 'low' },
+    { label: t('budget.medium'), value: 'medium' },
+    { label: t('budget.high'), value: 'high' },
+  ];
+
   return (
     <>
       <Typography variant="h6">{t('budget-label')}</Typography>
       <Select value={selectedBudget} onChange={handleSelectBudget}>
-        <MenuItem value="安い">{t('budget.low')}</MenuItem>
-        <MenuItem value="普通">{t('budget.medium')}</MenuItem>
-        <MenuItem value="高級">{t('budget.high')}</MenuItem>
+        {budgets.map((budget) => (
+          <MenuItem key={budget.value} value={budget.value}>
+            {budget.label}
+          </MenuItem>
+        ))}
       </Select>
     </>
   );

--- a/frontend/src/components/prompt/form/BudgetForm.tsx
+++ b/frontend/src/components/prompt/form/BudgetForm.tsx
@@ -1,0 +1,25 @@
+import type { SelectChangeEvent } from '@mui/material';
+import { Typography, Select, MenuItem } from '@mui/material';
+import createTranslation from 'next-translate/useTranslation';
+
+type Props = {
+  selectedBudget: string;
+  handleSelectBudget: (e: SelectChangeEvent) => void;
+};
+
+const PaceForm = ({ selectedBudget, handleSelectBudget }: Props) => {
+  const { t } = createTranslation('home');
+
+  return (
+    <>
+      <Typography variant="h6">{t('budget-label')}</Typography>
+      <Select value={selectedBudget} onChange={handleSelectBudget}>
+        <MenuItem value="安い">{t('budget.low')}</MenuItem>
+        <MenuItem value="普通">{t('budget.medium')}</MenuItem>
+        <MenuItem value="高級">{t('budget.high')}</MenuItem>
+      </Select>
+    </>
+  );
+};
+
+export default PaceForm;

--- a/frontend/src/components/prompt/form/DateRangeForm.tsx
+++ b/frontend/src/components/prompt/form/DateRangeForm.tsx
@@ -1,0 +1,21 @@
+import { Box, Typography } from '@mui/material';
+import { LocalizationProvider, DatePicker } from '@mui/x-date-pickers';
+import { AdapterMoment } from '@mui/x-date-pickers/AdapterMoment';
+import createTranslation from 'next-translate/useTranslation';
+
+const DateRangeForm = () => {
+  const { t } = createTranslation('home');
+
+  return (
+    <LocalizationProvider dateAdapter={AdapterMoment}>
+      <Typography variant="h6">{t('date-label')}</Typography>
+      <Box sx={{ display: 'flex', flexDirection: 'row', gap: 2 }}>
+        <DatePicker label={t('date-from-label')} />
+        <Typography sx={{ marginY: 'auto' }}>~</Typography>
+        <DatePicker label={t('date-until-label')} />
+      </Box>
+    </LocalizationProvider>
+  );
+};
+
+export default DateRangeForm;

--- a/frontend/src/components/prompt/form/DateRangeForm.tsx
+++ b/frontend/src/components/prompt/form/DateRangeForm.tsx
@@ -26,6 +26,7 @@ const DateRangeForm = ({ fromDate, handleFromDateChange, toDate, handleToDateCha
         <DatePicker
           label={t('date-until-label')}
           value={toDate}
+          minDate={fromDate}
           onChange={(newDate) => handleToDateChange(newDate)}
         />
       </Box>

--- a/frontend/src/components/prompt/form/DateRangeForm.tsx
+++ b/frontend/src/components/prompt/form/DateRangeForm.tsx
@@ -3,16 +3,31 @@ import { LocalizationProvider, DatePicker } from '@mui/x-date-pickers';
 import { AdapterMoment } from '@mui/x-date-pickers/AdapterMoment';
 import createTranslation from 'next-translate/useTranslation';
 
-const DateRangeForm = () => {
+type Props = {
+  fromDate: Date | null;
+  handleFromDateChange: (date: Date | null) => void;
+  toDate: Date | null;
+  handleToDateChange: (date: Date | null) => void;
+};
+
+const DateRangeForm = ({ fromDate, handleFromDateChange, toDate, handleToDateChange }: Props) => {
   const { t } = createTranslation('home');
 
   return (
     <LocalizationProvider dateAdapter={AdapterMoment}>
       <Typography variant="h6">{t('date-label')}</Typography>
       <Box sx={{ display: 'flex', flexDirection: 'row', gap: 2 }}>
-        <DatePicker label={t('date-from-label')} />
+        <DatePicker
+          label={t('date-from-label')}
+          value={fromDate}
+          onChange={(newDate) => handleFromDateChange(newDate)}
+        />
         <Typography sx={{ marginY: 'auto' }}>~</Typography>
-        <DatePicker label={t('date-until-label')} />
+        <DatePicker
+          label={t('date-until-label')}
+          value={toDate}
+          onChange={(newDate) => handleToDateChange(newDate)}
+        />
       </Box>
     </LocalizationProvider>
   );

--- a/frontend/src/components/prompt/form/DateRangeForm.tsx
+++ b/frontend/src/components/prompt/form/DateRangeForm.tsx
@@ -18,12 +18,14 @@ const DateRangeForm = ({ fromDate, handleFromDateChange, toDate, handleToDateCha
       <Typography variant="h6">{t('date-label')}</Typography>
       <Box sx={{ display: 'flex', flexDirection: 'row', gap: 2 }}>
         <DatePicker
+          sx={{ width: '100%' }}
           label={t('date-from-label')}
           value={fromDate}
           onChange={(newDate) => handleFromDateChange(newDate)}
         />
         <Typography sx={{ marginY: 'auto' }}>~</Typography>
         <DatePicker
+          sx={{ width: '100%' }}
           label={t('date-until-label')}
           value={toDate}
           minDate={fromDate}

--- a/frontend/src/components/prompt/form/InterestsForm.tsx
+++ b/frontend/src/components/prompt/form/InterestsForm.tsx
@@ -1,0 +1,59 @@
+import { Typography, Box, Chip } from '@mui/material';
+import createTranslation from 'next-translate/useTranslation';
+
+type Props = {
+  selectedInterests: string[];
+  handleSelectInterest: (interestLabel: string) => void;
+};
+
+const InterestsForm = ({ selectedInterests, handleSelectInterest }: Props) => {
+  const { t } = createTranslation('home');
+
+  const interests = [
+    t('interests.food'),
+    t('interests.nature'),
+    t('interests.shopping'),
+    t('interests.sports'),
+    t('interests.culture'),
+    t('interests.art'),
+    t('interests.history'),
+    t('interests.museum'),
+    t('interests.adventure'),
+    t('interests.sightseeing'),
+    t('interests.festival'),
+    t('interests.party'),
+    t('interests.photo'),
+    t('interests.beach'),
+    t('interests.mountain'),
+    t('interests.temple'),
+    t('interests.park'),
+    t('interests.zoo'),
+    t('interests.aquarium'),
+    t('interests.amusement'),
+  ];
+
+  return (
+    <>
+      <Typography variant="h6">{t('interests-label')}</Typography>
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
+        {interests.map((interest) => (
+          <Chip
+            key={interest}
+            label={interest}
+            clickable
+            onClick={() => handleSelectInterest(interest)}
+            sx={{
+              backgroundColor: selectedInterests.includes(interest) ? 'primary.main' : undefined,
+              color: selectedInterests.includes(interest) ? 'white' : undefined,
+              '&:hover': {
+                backgroundColor: selectedInterests.includes(interest) ? 'primary.main' : undefined,
+              },
+            }}
+          />
+        ))}
+      </Box>
+    </>
+  );
+};
+
+export default InterestsForm;

--- a/frontend/src/components/prompt/form/InterestsForm.tsx
+++ b/frontend/src/components/prompt/form/InterestsForm.tsx
@@ -35,7 +35,7 @@ const InterestsForm = ({ selectedInterests, handleSelectInterest }: Props) => {
   return (
     <>
       <Typography variant="h6">{t('interests-label')}</Typography>
-      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
         {interests.map((interest) => (
           <Chip
             key={interest}

--- a/frontend/src/components/prompt/form/InterestsForm.tsx
+++ b/frontend/src/components/prompt/form/InterestsForm.tsx
@@ -10,26 +10,26 @@ const InterestsForm = ({ selectedInterests, handleSelectInterest }: Props) => {
   const { t } = createTranslation('home');
 
   const interests = [
-    t('interests.food'),
-    t('interests.nature'),
-    t('interests.shopping'),
-    t('interests.sports'),
-    t('interests.culture'),
-    t('interests.art'),
-    t('interests.history'),
-    t('interests.museum'),
-    t('interests.adventure'),
-    t('interests.sightseeing'),
-    t('interests.festival'),
-    t('interests.party'),
-    t('interests.photo'),
-    t('interests.beach'),
-    t('interests.mountain'),
-    t('interests.temple'),
-    t('interests.park'),
-    t('interests.zoo'),
-    t('interests.aquarium'),
-    t('interests.amusement'),
+    { label: t('interests.food'), value: 'food' },
+    { label: t('interests.nature'), value: 'nature' },
+    { label: t('interests.shopping'), value: 'shopping' },
+    { label: t('interests.sports'), value: 'sports' },
+    { label: t('interests.culture'), value: 'culture' },
+    { label: t('interests.art'), value: 'art' },
+    { label: t('interests.history'), value: 'history' },
+    { label: t('interests.museum'), value: 'museum' },
+    { label: t('interests.adventure'), value: 'adventure' },
+    { label: t('interests.sightseeing'), value: 'sightseeing' },
+    { label: t('interests.festival'), value: 'festival' },
+    { label: t('interests.party'), value: 'party' },
+    { label: t('interests.photo'), value: 'photo' },
+    { label: t('interests.beach'), value: 'beach' },
+    { label: t('interests.mountain'), value: 'mountain' },
+    { label: t('interests.temple'), value: 'temple' },
+    { label: t('interests.park'), value: 'park' },
+    { label: t('interests.zoo'), value: 'zoo' },
+    { label: t('interests.aquarium'), value: 'aquarium' },
+    { label: t('interests.amusement'), value: 'amusement' },
   ];
 
   return (
@@ -38,15 +38,19 @@ const InterestsForm = ({ selectedInterests, handleSelectInterest }: Props) => {
       <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
         {interests.map((interest) => (
           <Chip
-            key={interest}
-            label={interest}
+            key={interest.value}
+            label={interest.label}
             clickable
-            onClick={() => handleSelectInterest(interest)}
+            onClick={() => handleSelectInterest(interest.value)}
             sx={{
-              backgroundColor: selectedInterests.includes(interest) ? 'primary.main' : undefined,
-              color: selectedInterests.includes(interest) ? 'white' : undefined,
+              backgroundColor: selectedInterests.includes(interest.value)
+                ? 'primary.main'
+                : undefined,
+              color: selectedInterests.includes(interest.value) ? 'white' : undefined,
               '&:hover': {
-                backgroundColor: selectedInterests.includes(interest) ? 'primary.main' : undefined,
+                backgroundColor: selectedInterests.includes(interest.value)
+                  ? 'primary.main'
+                  : undefined,
               },
             }}
           />

--- a/frontend/src/components/prompt/form/PaceForm.tsx
+++ b/frontend/src/components/prompt/form/PaceForm.tsx
@@ -1,0 +1,25 @@
+import type { SelectChangeEvent } from '@mui/material';
+import { Typography, Select, MenuItem } from '@mui/material';
+import createTranslation from 'next-translate/useTranslation';
+
+type Props = {
+  selectedPace: string;
+  handleSelectPace: (e: SelectChangeEvent) => void;
+};
+
+const PaceForm = ({ selectedPace, handleSelectPace }: Props) => {
+  const { t } = createTranslation('home');
+
+  return (
+    <>
+      <Typography variant="h6">{t('pace-label')}</Typography>
+      <Select value={selectedPace} onChange={handleSelectPace}>
+        <MenuItem value="ゆっくり">{t('pace.relaxed')}</MenuItem>
+        <MenuItem value="普通">{t('pace.normal')}</MenuItem>
+        <MenuItem value="せっかち">{t('pace.packed')}</MenuItem>
+      </Select>
+    </>
+  );
+};
+
+export default PaceForm;

--- a/frontend/src/components/prompt/form/PaceForm.tsx
+++ b/frontend/src/components/prompt/form/PaceForm.tsx
@@ -10,13 +10,21 @@ type Props = {
 const PaceForm = ({ selectedPace, handleSelectPace }: Props) => {
   const { t } = createTranslation('home');
 
+  const paces = [
+    { label: t('pace.relaxed'), value: 'relaxed' },
+    { label: t('pace.normal'), value: 'normal' },
+    { label: t('pace.packed'), value: 'packed' },
+  ];
+
   return (
     <>
       <Typography variant="h6">{t('pace-label')}</Typography>
       <Select value={selectedPace} onChange={handleSelectPace}>
-        <MenuItem value="ゆっくり">{t('pace.relaxed')}</MenuItem>
-        <MenuItem value="普通">{t('pace.normal')}</MenuItem>
-        <MenuItem value="せっかち">{t('pace.packed')}</MenuItem>
+        {paces.map((pace) => (
+          <MenuItem key={pace.value} value={pace.value}>
+            {pace.label}
+          </MenuItem>
+        ))}
       </Select>
     </>
   );

--- a/frontend/src/components/prompt/form/PeopleNumberForm.tsx
+++ b/frontend/src/components/prompt/form/PeopleNumberForm.tsx
@@ -1,0 +1,30 @@
+import { Typography, TextField } from '@mui/material';
+import createTranslation from 'next-translate/useTranslation';
+import type { ChangeEvent } from 'react';
+
+type Props = {
+  peopleNumber: number;
+  handlePeopleNumberChange: (e: ChangeEvent<HTMLInputElement>) => void;
+};
+
+const PeopleNumberForm = ({ peopleNumber, handlePeopleNumberChange }: Props) => {
+  const { t } = createTranslation('home');
+
+  return (
+    <>
+      <Typography variant="h6">{t('people-number-label')}</Typography>
+      <TextField
+        type="number"
+        error={peopleNumber < 1}
+        value={peopleNumber}
+        onChange={handlePeopleNumberChange}
+        inputProps={{
+          inputMode: 'numeric',
+          pattern: '[0-9]*',
+        }}
+      />
+    </>
+  );
+};
+
+export default PeopleNumberForm;

--- a/frontend/src/components/prompt/form/TripTypeForm.tsx
+++ b/frontend/src/components/prompt/form/TripTypeForm.tsx
@@ -1,0 +1,28 @@
+import type { SelectChangeEvent } from '@mui/material';
+import { Select, MenuItem, Typography } from '@mui/material';
+import createTranslation from 'next-translate/useTranslation';
+
+type Props = {
+  selectedTripTypes: string;
+  handleSelectTripType: (e: SelectChangeEvent) => void;
+};
+
+const TripTypeForm = ({ selectedTripTypes, handleSelectTripType }: Props) => {
+  const { t } = createTranslation('home');
+
+  return (
+    <>
+      <Typography variant="h6">{t('trip-type-label')}</Typography>
+      <Select value={selectedTripTypes} onChange={handleSelectTripType}>
+        <MenuItem value="一人">{t('trip-type.solo')}</MenuItem>
+        <MenuItem value="カップル">{t('trip-type.couple')}</MenuItem>
+        <MenuItem value="家族">{t('trip-type.family')}</MenuItem>
+        <MenuItem value="友達">{t('trip-type.friends')}</MenuItem>
+        <MenuItem value="ビジネス">{t('trip-type.business')}</MenuItem>
+        <MenuItem value="バックパッカー">{t('trip-type.backpacker')}</MenuItem>
+      </Select>
+    </>
+  );
+};
+
+export default TripTypeForm;

--- a/frontend/src/components/prompt/form/TripTypeForm.tsx
+++ b/frontend/src/components/prompt/form/TripTypeForm.tsx
@@ -10,16 +10,24 @@ type Props = {
 const TripTypeForm = ({ selectedTripTypes, handleSelectTripType }: Props) => {
   const { t } = createTranslation('home');
 
+  const tripTypes = [
+    { label: t('trip-type.solo'), value: 'solo' },
+    { label: t('trip-type.couple'), value: 'couple' },
+    { label: t('trip-type.family'), value: 'family' },
+    { label: t('trip-type.friends'), value: 'friends' },
+    { label: t('trip-type.business'), value: 'business' },
+    { label: t('trip-type.backpacker'), value: 'backpacker' },
+  ];
+
   return (
     <>
       <Typography variant="h6">{t('trip-type-label')}</Typography>
       <Select value={selectedTripTypes} onChange={handleSelectTripType}>
-        <MenuItem value="一人">{t('trip-type.solo')}</MenuItem>
-        <MenuItem value="カップル">{t('trip-type.couple')}</MenuItem>
-        <MenuItem value="家族">{t('trip-type.family')}</MenuItem>
-        <MenuItem value="友達">{t('trip-type.friends')}</MenuItem>
-        <MenuItem value="ビジネス">{t('trip-type.business')}</MenuItem>
-        <MenuItem value="バックパッカー">{t('trip-type.backpacker')}</MenuItem>
+        {tripTypes.map((tripType) => (
+          <MenuItem key={tripType.value} value={tripType.value}>
+            {tripType.label}
+          </MenuItem>
+        ))}
       </Select>
     </>
   );

--- a/frontend/src/hooks/usePreferences.tsx
+++ b/frontend/src/hooks/usePreferences.tsx
@@ -2,10 +2,20 @@ import type { SelectChangeEvent } from '@mui/material';
 import { useState } from 'react';
 
 export const usePreferences = () => {
+  const [fromDate, setFromDate] = useState<Date | null>(null);
+  const [toDate, setToDate] = useState<Date | null>(null);
   const [selectedTripType, setSelectedTripType] = useState('');
   const [selectedPace, setSelectedPace] = useState('');
   const [selectedBudget, setSelectedBudget] = useState('');
   const [selectedInterests, setSelectedInterests] = useState<string[]>([]);
+
+  const handleFromDateChange = (date: Date | null) => {
+    setFromDate(date);
+  };
+
+  const handleToDateChange = (date: Date | null) => {
+    setToDate(date);
+  };
 
   const handleSelectTripType = (e: SelectChangeEvent) => {
     setSelectedTripType(e.target.value);
@@ -28,6 +38,10 @@ export const usePreferences = () => {
   };
 
   return {
+    fromDate,
+    handleFromDateChange,
+    toDate,
+    handleToDateChange,
     selectedTripType,
     handleSelectTripType,
     selectedPace,

--- a/frontend/src/hooks/usePreferences.tsx
+++ b/frontend/src/hooks/usePreferences.tsx
@@ -1,0 +1,40 @@
+import type { SelectChangeEvent } from '@mui/material';
+import { useState } from 'react';
+
+export const usePreferences = () => {
+  const [selectedTripType, setSelectedTripType] = useState('');
+  const [selectedPace, setSelectedPace] = useState('');
+  const [selectedBudget, setSelectedBudget] = useState('');
+  const [selectedInterests, setSelectedInterests] = useState<string[]>([]);
+
+  const handleSelectTripType = (e: SelectChangeEvent) => {
+    setSelectedTripType(e.target.value);
+  };
+
+  const handleSelectPace = (e: SelectChangeEvent) => {
+    setSelectedPace(e.target.value);
+  };
+
+  const handleSelectBudget = (e: SelectChangeEvent) => {
+    setSelectedBudget(e.target.value);
+  };
+
+  const handleSelectInterest = (interestLabel: string) => {
+    if (selectedInterests.includes(interestLabel)) {
+      setSelectedInterests((prevLabel) => prevLabel.filter((label) => label !== interestLabel));
+    } else {
+      setSelectedInterests((prevLabel) => [...prevLabel, interestLabel]);
+    }
+  };
+
+  return {
+    selectedTripType,
+    handleSelectTripType,
+    selectedPace,
+    handleSelectPace,
+    selectedBudget,
+    handleSelectBudget,
+    selectedInterests,
+    handleSelectInterest,
+  };
+};

--- a/frontend/src/hooks/usePreferences.tsx
+++ b/frontend/src/hooks/usePreferences.tsx
@@ -1,9 +1,11 @@
 import type { SelectChangeEvent } from '@mui/material';
+import type { ChangeEvent } from 'react';
 import { useState } from 'react';
 
 export const usePreferences = () => {
   const [fromDate, setFromDate] = useState<Date | null>(null);
   const [toDate, setToDate] = useState<Date | null>(null);
+  const [peopleNumber, setPeopleNumber] = useState(1);
   const [selectedTripType, setSelectedTripType] = useState('');
   const [selectedPace, setSelectedPace] = useState('');
   const [selectedBudget, setSelectedBudget] = useState('');
@@ -15,6 +17,14 @@ export const usePreferences = () => {
 
   const handleToDateChange = (date: Date | null) => {
     setToDate(date);
+  };
+
+  const handlePeopleNumberChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const value = Number(e.target.value);
+    if (value < 1) {
+      return;
+    }
+    setPeopleNumber(value);
   };
 
   const handleSelectTripType = (e: SelectChangeEvent) => {
@@ -42,6 +52,8 @@ export const usePreferences = () => {
     handleFromDateChange,
     toDate,
     handleToDateChange,
+    peopleNumber,
+    handlePeopleNumberChange,
     selectedTripType,
     handleSelectTripType,
     selectedPace,


### PR DESCRIPTION
## Background
Add a modal for asking user travel preferences such as date, trip type, pace, budget and interests

## Summary
Implement a modal asking for user preferences after submit the data in the input bar
[Figma on planning section](https://www.figma.com/file/TXTmhow5ovM3eZjOZy3ID5/FirstDraft-HomePage?type=design&node-id=35-616&mode=design&t=m36hKQ6PFOIhSnC4-0)

I made the state management logic into a `usePreferences` hook, and pass it as props for each respective form for separation of concerns and making the code short and readable

![image](https://github.com/chanon-mike/smart-ryokou/assets/27944646/b907edfe-1dbe-4b49-b2ab-d987ff943bdf)


## Test Cases
- [ ] Enter information in input bar
- [ ] Modal appeared, with date, trip type, pace, budget and interests label
- [ ] Enter information and close modal, open modal again and data is saved
- [ ] Change language to Japanese and English display in each respective language