### PR TITLE
Set optional json properties in POST request to null when user do not input + disable submit button when user not input date

### DIFF
--- a/frontend/src/components/prompt/PreferencesModal.tsx
+++ b/frontend/src/components/prompt/PreferencesModal.tsx
@@ -58,6 +58,7 @@ const PreferencesModal = ({
   const ht = homeT.t;
   const ct = commonT.t;
 
+  // eslint-disable-next-line complexity
   const handleSubmit = async () => {
     let serverResponse: GetResultResponse;
     try {
@@ -68,10 +69,10 @@ const PreferencesModal = ({
           date_from: fromDate ? fromDate.toISOString() : '',
           date_to: toDate ? toDate.toISOString() : '',
           people_num: peopleNumber,
-          budget: selectedBudget,
-          trip_pace: selectedPace,
-          interests: selectedInterests,
-          trip_type: selectedTripType,
+          budget: selectedBudget.length ? selectedBudget : null,
+          trip_pace: selectedPace.length ? selectedPace : null,
+          interests: selectedInterests.length ? selectedInterests : null,
+          trip_type: selectedTripType.length ? selectedTripType : null,
         } as GetResultRequest,
       );
     } catch (error) {
@@ -114,7 +115,7 @@ const PreferencesModal = ({
       </DialogContent>
       <DialogActions sx={{ margin: 3 }}>
         <Button onClick={handleCloseModal}>{ct('cancel')}</Button>
-        <Button onClick={handleSubmit} variant="contained">
+        <Button onClick={handleSubmit} variant="contained" disabled={!fromDate || !toDate}>
           {ct('finish')}
         </Button>
       </DialogActions>


### PR DESCRIPTION
#### 1: Problem 
![image](https://github.com/chanon-mike/smart-ryokou/assets/56637459/25b39df9-255b-436b-b918-5f54a6b4073e)
Error when user click "Submit" button while leaving marked area blank

#### 2: Reason
- In backend, optional properties will have value None when there is no value but in frontend, an empty string is passed

#### 3: Solution
- In frontend, before sending request check var length and set null if length === 0
- Disable "Submit" button if either date_from and date_to is empty