### PR TITLE
Set lambda timeout to 50s

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -10,6 +10,7 @@ provider:
   runtime: python3.9
   stage: ${opt:stage, "dev"}
   region: ap-northeast-1
+  timeout: 50
   deploymentBucket:
     name: smart-ryokou-api
   environment:


### PR DESCRIPTION
## Background
Default AWS Lambda timeout is 6s which the gpt cause around 20~30s for each request.

## Summary
Set the timeout to 50s instead. 