### PR TITLE
Change date format when make request to openai endpoint

### DIFF
--- a/frontend/src/components/prompt/PreferencesModal.tsx
+++ b/frontend/src/components/prompt/PreferencesModal.tsx
@@ -65,13 +65,17 @@ const PreferencesModal = ({
     setIsLoading(true);
     handleCloseModal();
     let serverResponse: GetResultResponse;
+    const fromDateMonth = fromDate?.month(); // NOTE: Moment's month starts from 0
+    const fromDateDay = fromDate?.date();
+    const toDateMonth = toDate?.month(); // NOTE: Moment's month starts from 0
+    const toDateDay = toDate?.date();
     try {
       serverResponse = await Client.getResult(
         { useMock: false, requireAuth: false } as ApiContext,
         {
           place: placeInput,
-          date_from: fromDate ? fromDate.toISOString() : '',
-          date_to: toDate ? toDate.toISOString() : '',
+          date_from: fromDateMonth ? `${fromDateMonth + 1}月${fromDateDay}日` : '',
+          date_to: toDateMonth ? `${toDateMonth + 1}月${toDateDay}日` : '',
           people_num: peopleNumber,
           budget: selectedBudget.length ? selectedBudget : null,
           trip_pace: selectedPace.length ? selectedPace : null,

--- a/frontend/src/components/prompt/form/DateRangeForm.tsx
+++ b/frontend/src/components/prompt/form/DateRangeForm.tsx
@@ -1,13 +1,14 @@
 import { Box, Typography } from '@mui/material';
 import { LocalizationProvider, DatePicker } from '@mui/x-date-pickers';
 import { AdapterMoment } from '@mui/x-date-pickers/AdapterMoment';
+import type { Moment } from 'moment';
 import createTranslation from 'next-translate/useTranslation';
 
 type Props = {
-  fromDate: Date | null;
-  handleFromDateChange: (date: Date | null) => void;
-  toDate: Date | null;
-  handleToDateChange: (date: Date | null) => void;
+  fromDate: Moment | null;
+  handleFromDateChange: (date: Moment | null) => void;
+  toDate: Moment | null;
+  handleToDateChange: (date: Moment | null) => void;
 };
 
 const DateRangeForm = ({ fromDate, handleFromDateChange, toDate, handleToDateChange }: Props) => {

--- a/frontend/src/hooks/usePreferences.tsx
+++ b/frontend/src/hooks/usePreferences.tsx
@@ -1,21 +1,22 @@
 import type { SelectChangeEvent } from '@mui/material';
+import type { Moment } from 'moment';
 import type { ChangeEvent } from 'react';
 import { useState } from 'react';
 
 export const usePreferences = () => {
-  const [fromDate, setFromDate] = useState<Date | null>(null);
-  const [toDate, setToDate] = useState<Date | null>(null);
+  const [fromDate, setFromDate] = useState<Moment | null>(null);
+  const [toDate, setToDate] = useState<Moment | null>(null);
   const [peopleNumber, setPeopleNumber] = useState(1);
   const [selectedTripType, setSelectedTripType] = useState('');
   const [selectedPace, setSelectedPace] = useState('');
   const [selectedBudget, setSelectedBudget] = useState('');
   const [selectedInterests, setSelectedInterests] = useState<string[]>([]);
 
-  const handleFromDateChange = (date: Date | null) => {
+  const handleFromDateChange = (date: Moment | null) => {
     setFromDate(date);
   };
 
-  const handleToDateChange = (date: Date | null) => {
+  const handleToDateChange = (date: Moment | null) => {
     setToDate(date);
   };
 


### PR DESCRIPTION
### Bug:
- Inputted date range and response date range do not match
![image](https://github.com/chanon-mike/smart-ryokou/assets/56637459/c27d06b8-cf4a-4498-b181-0b6f5179c5e7)
![image](https://github.com/chanon-mike/smart-ryokou/assets/56637459/84b23c6d-19d9-4840-8d9a-5c47cfa4cce4)

### Cause
- Date format send to backend is ISO string

### Fix
- Extract month and date and send in format `10月10日`