### PR TITLE
Add redis instance for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,6 @@ poetry/core/*
 .secrets
 
 .serverless
+
+# redis
+data/redis

--- a/README.md
+++ b/README.md
@@ -36,3 +36,5 @@ Always checkout from and merge to develop branch
    ```
 
 5. Open [http://localhost:3000](http://localhost:3000) and [http://localhost:8000](http://localhost:8000) with your browser to see the result.
+
+6. Run `docker compose up -d` to boot redis instance

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,7 @@
+services:
+  redis:
+    image: "redis:latest"
+    ports:
+      - "6379:6379"
+    volumes:
+      - "./data/redis:/data"


### PR DESCRIPTION
## Background
Redis is needed to cache a gpt session

## Summary
Add docker compose file for a redis instance

## Test cases
- [x] Open docker desktop
- [x] Run `docker compose up -d`
- [x] New docker instance appear on docker desktop (or run `docker ps` command)
- [x] Run `redis-cli` from root directory or from docker `docker exec -it smart-ryokou-redis /bin/bash` 
- [x] Run `127.0.0.1:6379> keys *` and `(empty list or set)` appear
