### PR TITLE
Fix NEXT_PUBLIC for Google Maps API key and implement all env in one file

### DIFF
--- a/frontend/src/client/api/GetResult/implement.ts
+++ b/frontend/src/client/api/GetResult/implement.ts
@@ -9,8 +9,8 @@ import type {
 import axios from 'axios';
 import type { Recommendation, Location } from '@/types/recommendation';
 import getLocationData from '@/client/helper/getLocationData';
-import MapConfigs from '@/libs/MapConfigs';
 import cacheClient from '@/client/service/cache/implement';
+import { API_ENDPOINT, GOOGLE_MAPS_API_KEY } from '@/libs/envValues';
 
 // eslint-disable-next-line complexity
 const getResult: GetResultInterface = async (context: ApiContext, request: GetResultRequest) => {
@@ -22,8 +22,6 @@ const getResult: GetResultInterface = async (context: ApiContext, request: GetRe
     return getResultMock(request);
   }
 
-  const BACKEND_ENDPOINT = process.env.NEXT_PUBLIC_API_ENDPOINT ?? 'http://localhost:8000';
-
   let serverResponse: GetResultServerResponse;
 
   // TODO: hash instead stringify
@@ -33,7 +31,7 @@ const getResult: GetResultInterface = async (context: ApiContext, request: GetRe
   if (cachedResult === null) {
     try {
       serverResponse = (
-        await axios.post(`${BACKEND_ENDPOINT}/api/recommendation/structured-format`, request)
+        await axios.post(`${API_ENDPOINT}/api/recommendation/structured-format`, request)
       ).data;
 
       cacheClient.setKey(cacheKey, JSON.stringify(serverResponse));
@@ -65,8 +63,7 @@ const adapter = async (serverResponse: GetResultServerResponse) => {
             date: r.date,
             locations: await Promise.all(
               r.activities.map(async (a: { place: string; description: string }) => {
-                const { API_KEY } = MapConfigs();
-                const data = await getLocationData(a.place, API_KEY);
+                const data = await getLocationData(a.place, GOOGLE_MAPS_API_KEY);
                 return {
                   name: a.place,
                   description: a.description,

--- a/frontend/src/components/recommendation/map/Map.tsx
+++ b/frontend/src/components/recommendation/map/Map.tsx
@@ -4,9 +4,7 @@ import { Box, CardMedia, Paper, Typography } from '@mui/material';
 import { LoadScript, GoogleMap, Marker } from '@react-google-maps/api';
 import { useContext } from 'react';
 import { ActiveLocationContext } from '../ActiveLocationContext';
-import MapConfigs from '@/libs/MapConfigs';
-
-const { API_KEY } = MapConfigs();
+import { GOOGLE_MAPS_API_KEY } from '@/libs/envValues';
 
 const Map = () => {
   const activeLocationContext = useContext(ActiveLocationContext);
@@ -14,7 +12,7 @@ const Map = () => {
 
   return (
     <div style={{ width: '100%', height: '100%', position: 'relative' }}>
-      <LoadScript googleMapsApiKey={API_KEY}>
+      <LoadScript googleMapsApiKey={GOOGLE_MAPS_API_KEY}>
         <GoogleMap
           mapContainerStyle={{ width: '100%', height: '100%' }}
           center={mapCenter}

--- a/frontend/src/libs/MapConfigs.tsx
+++ b/frontend/src/libs/MapConfigs.tsx
@@ -1,9 +1,0 @@
-const MapConfigs = () => {
-  const API_KEY = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API ?? '';
-
-  return {
-    API_KEY,
-  };
-};
-
-export default MapConfigs;

--- a/frontend/src/libs/envValues.ts
+++ b/frontend/src/libs/envValues.ts
@@ -1,1 +1,10 @@
+// Database
+export const REDIS_CONNECTION_URL = process.env.REDIS_CONNECTION_URL ?? 'localhost:6379';
+export const MONGODB_URI = process.env.MONGODB_URI ?? '';
+
+// Google Map
+export const GOOGLE_MAPS_API_KEY = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API ?? '';
+
+// Public
+export const API_ENDPOINT = process.env.NEXT_PUBLIC_API_ENDPOINT ?? 'http://localhost:8000';
 export const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID ?? '';

--- a/frontend/src/service/cache/service.ts
+++ b/frontend/src/service/cache/service.ts
@@ -1,7 +1,8 @@
 import { Redis } from 'ioredis';
 import type CacheServiceInterface from './interface';
+import { REDIS_CONNECTION_URL } from '@/libs/envValues';
 
-const redisClient: Redis = new Redis(process.env.REDIS_CONNECTION_URL ?? 'localhost:6379'); // default local
+const redisClient: Redis = new Redis(REDIS_CONNECTION_URL);
 
 class CacheService implements CacheServiceInterface {
   private client: Redis;

--- a/frontend/src/service/database/base/client.ts
+++ b/frontend/src/service/database/base/client.ts
@@ -1,10 +1,11 @@
+import { MONGODB_URI } from '@/libs/envValues';
 import { MongoClient } from 'mongodb';
 
-if (!process.env.MONGODB_URI) {
+if (MONGODB_URI === '') {
   throw new Error('Invalid/Missing environment variable: "MONGODB_URI"');
 }
 
-const uri = process.env.MONGODB_URI;
+const uri = MONGODB_URI;
 const options = {};
 
 let client;


### PR DESCRIPTION
## Background
Environment variable start with `NEXT_PUBLIC` will be able to used in component file (`.jsx .tsx`) which will be rendered to browser. Without `NEXT_PUBLIC` will be on the node side which user cannot see.  Google Maps API key is using `NEXT_PUBLIC` so there may be a chance of leaking?

## Summary
- Change Google Maps API variable name
- Implement all env in `libs/envValues.ts` instead for easier managing

## Breaking Changes!!!
- [ ] Change `/frontend/.env` variable name from `NEXT_PUBLIC_GOOGLE_MAPS_API` to `GOOGLE_MAPS_API_KEY`. 

Take a look at [Notion](https://www.notion.so/Environment-Variables-04661914a3ce40bcb09edc77d9e36c35?pvs=4) for new .env file