### PR TITLE
Fix sometimes cannot fetch location and image

### DIFF
--- a/frontend/src/client/api/get-new-location/implement.ts
+++ b/frontend/src/client/api/get-new-location/implement.ts
@@ -47,7 +47,8 @@ const getLocation: GetNewLocationInterface = async (
     serverResponse = JSON.parse(cachedResult);
   }
 
-  return adapter(serverResponse);
+  const result = await adapter(serverResponse);
+  return result;
 };
 
 // Data Example: {'recommendations': [{'place': 'Kanazawa', 'description': 'Kanazawa is known for its rich history and traditional arts. It is home to several museums, including the Ishikawa Prefectural Museum of Art and the 21st Century Museum of Contemporary Art.'}, {'place': 'Hakone', 'description': 'Hakone is a popular tourist destination known for its hot springs and natural beauty. It is home to the Hakone Open-Air Museum, which features a large collection of outdoor sculptures.'}, {'place': 'Nikko', 'description': 'Nikko is a historic city famous for its shrines and temples. It is home to the Nikko Toshogu Shrine, a UNESCO World Heritage site, and the Nikko Tamozawa Imperial Villa Memorial Park.'}]}

--- a/frontend/src/client/api/get-result/implement.ts
+++ b/frontend/src/client/api/get-result/implement.ts
@@ -44,7 +44,8 @@ const getResult: GetResultInterface = async (context: ApiContext, request: GetRe
     serverResponse = JSON.parse(cachedResult);
   }
 
-  return adapter(serverResponse);
+  const result = await adapter(serverResponse);
+  return result;
 };
 
 // TODO: Refactor

--- a/frontend/src/client/helper/getImageData.ts
+++ b/frontend/src/client/helper/getImageData.ts
@@ -21,9 +21,15 @@ export const getImageData = async (
         `https://www.googleapis.com/customsearch/v1?q=${placeName}&key=${apiKey}&cx=${cx}&searchType=image`,
       )
     ).data;
-    const imageData = response.items[0].link;
-
-    cacheClient.setKey(cacheKey, JSON.stringify(imageData));
+    let imageData;
+    if (response.items) {
+      imageData = response.items[0].link;
+      cacheClient.setKey(cacheKey, JSON.stringify(imageData));
+    } else {
+      // When google cannot find image, use default
+      imageData =
+        'https://fastly.picsum.photos/id/43/100/100.jpg?hmac=QWvBJMVtL0V3YvT4uaJ4stLVLJ0Nx053a7i4F2UXGYk';
+    }
 
     return imageData;
   } catch (error) {

--- a/frontend/src/client/helper/getLocationData.ts
+++ b/frontend/src/client/helper/getLocationData.ts
@@ -19,12 +19,18 @@ const getLocationData = async (placeName: string, apiKey: string) => {
         `https://maps.googleapis.com/maps/api/geocode/json?address=${placeName}&key=${apiKey}`,
       )
     ).data;
-    const locationData: { lat: number; lng: number } = response.results[0].geometry.location;
 
-    cacheClient.setKey(cacheKey, JSON.stringify(locationData));
+    let locationData: { lat: number; lng: number };
+    if (response.results.length === 0) {
+      locationData = { lat: 0, lng: 0 };
+    } else {
+      locationData = response.results[0].geometry.location;
 
+      cacheClient.setKey(cacheKey, JSON.stringify(locationData));
+    }
     return locationData;
   } catch (error) {
+    console.log(`error`, error);
     throw new Error('An unexpected error occurred while fetching location data');
   }
 };

--- a/frontend/src/components/recommendation/prompt/PreferencesModal.tsx
+++ b/frontend/src/components/recommendation/prompt/PreferencesModal.tsx
@@ -98,7 +98,7 @@ const PreferencesModal = ({
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     setIsLoading(true);
     handleCloseModal();
-
+    console.log(`handleSubmit run`);
     let serverResponse: GetResultResponse;
     try {
       const requestParams = buildRequestParams();
@@ -112,6 +112,7 @@ const PreferencesModal = ({
       }
       return;
     }
+    console.log(`serverResponse after input modal`, serverResponse);
 
     const sessionClient = new SessionClient();
 


### PR DESCRIPTION
### What
- Sometimes, when location is not famous or server error -> cannot find location and image. In those cases, return default value `{lat: 0, lng:0}` for location and `https://fastly.picsum.photos/id/43/100/100.jpg?hmac=QWvBJMVtL0V3YvT4uaJ4stLVLJ0Nx053a7i4F2UXGYk` for image and DO NOT save in cache.