### PR TITLE
feat: Add id to location and change dnd id to location.id

### DIFF
--- a/frontend/src/client/api/get-new-location/implement.ts
+++ b/frontend/src/client/api/get-new-location/implement.ts
@@ -12,6 +12,7 @@ import cacheClient from '@/client/service/cache/implement';
 import { API_ENDPOINT, CX, GOOGLE_MAPS_API_KEY, GOOGLE_SEARCH_API_KEY } from '@/libs/envValues';
 import getNewLocationMock from './mock';
 import { getImageData } from '@/client/helper/getImageData';
+import { generateObjectId } from '@/libs/helper';
 
 // eslint-disable-next-line complexity
 const getLocation: GetNewLocationInterface = async (
@@ -66,6 +67,7 @@ const adapter = async (
 
         if (latLngData.lat !== undefined && latLngData.lng !== undefined) {
           locations.push({
+            id: generateObjectId(),
             name: recommendation.place,
             description: recommendation.description,
             imageUrl: imageData,

--- a/frontend/src/client/api/get-result/implement.ts
+++ b/frontend/src/client/api/get-result/implement.ts
@@ -12,6 +12,7 @@ import getLocationData from '@/client/helper/getLocationData';
 import cacheClient from '@/client/service/cache/implement';
 import { API_ENDPOINT, CX, GOOGLE_MAPS_API_KEY, GOOGLE_SEARCH_API_KEY } from '@/libs/envValues';
 import { getImageData } from '@/client/helper/getImageData';
+import { generateObjectId } from '@/libs/helper';
 
 // eslint-disable-next-line complexity
 const getResult: GetResultInterface = async (context: ApiContext, request: GetResultRequest) => {
@@ -70,6 +71,7 @@ const adapter = async (serverResponse: GetResultServerResponse) => {
                 const imageData = await getImageData(a.place, GOOGLE_SEARCH_API_KEY, CX);
 
                 return {
+                  id: generateObjectId(),
                   name: a.place,
                   description: a.description,
                   imageUrl: imageData,

--- a/frontend/src/components/recommendation/list/DroppableDateList.tsx
+++ b/frontend/src/components/recommendation/list/DroppableDateList.tsx
@@ -29,7 +29,7 @@ const DroppableDateList: FC<DroppableDateListProps> = ({ recommendation, onConfi
 
   return (
     <SortableContext
-      items={recommendation.locations.map((loc) => loc.name)}
+      items={recommendation.locations.map((loc) => loc.id)}
       strategy={rectSortingStrategy}
     >
       <Typography variant="h6" sx={{ marginTop: 1 }}>

--- a/frontend/src/components/recommendation/list/RecommendationContainer.tsx
+++ b/frontend/src/components/recommendation/list/RecommendationContainer.tsx
@@ -76,7 +76,7 @@ const RecommendationContainer = () => {
               <SortableLocationCard
                 location={
                   session.recommendations[activeContainerIndex].locations.filter(
-                    (r) => r.name === activeId,
+                    (loc) => loc.id === activeId,
                   )[0]
                 }
               />

--- a/frontend/src/components/recommendation/list/SortableLocationCard.tsx
+++ b/frontend/src/components/recommendation/list/SortableLocationCard.tsx
@@ -38,7 +38,7 @@ const SortableLocationCard = ({
   onConfirmDelete,
 }: SortableLocationCardProps) => {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
-    id: location.name,
+    id: location.id,
     disabled,
   });
 

--- a/frontend/src/components/recommendation/list/new-location/NewLocationInput.tsx
+++ b/frontend/src/components/recommendation/list/new-location/NewLocationInput.tsx
@@ -75,7 +75,7 @@ const NewLocationInput = ({
   const handleAddLocation = (location: Location) => {
     // When add location, remove that location from newLocations
     setNewLocations((prev: Location[]) => {
-      const newLocations = prev.filter((loc) => loc.name !== location.name);
+      const newLocations = prev.filter((loc) => loc.id !== location.name);
       return newLocations;
     });
     setSession((prev: Session) => {

--- a/frontend/src/components/recommendation/list/useDnd.tsx
+++ b/frontend/src/components/recommendation/list/useDnd.tsx
@@ -30,7 +30,7 @@ export const useDnd = ({
   const handleDragStart = (event: DragStartEvent) => {
     const { active } = event;
     const activeDateContainerIndex = session.recommendations.findIndex((r) =>
-      r.locations.some((loc) => loc.name === active.id),
+      r.locations.some((loc) => loc.id === active.id),
     );
 
     setActiveId(active.id);
@@ -51,7 +51,7 @@ export const useDnd = ({
     }
 
     const overContainerIndex = session.recommendations.findIndex((r) =>
-      r.locations.some((loc) => loc.name === over.id),
+      r.locations.some((loc) => loc.id === over.id),
     );
 
     if (activeContainerIndex === null || activeContainerIndex === overContainerIndex) {
@@ -68,7 +68,7 @@ export const useDnd = ({
       }
 
       const [activeItem] = activeContainer.locations.splice(
-        activeContainer.locations.findIndex((loc) => loc.name === active.id),
+        activeContainer.locations.findIndex((loc) => loc.id === active.id),
         1,
       );
       next[overContainerIndex]?.locations.push(activeItem); // This places the item at the end of the target Container
@@ -96,10 +96,10 @@ export const useDnd = ({
     setSession((prev) => {
       const newRecommendation = [...prev.recommendations];
       const activeContainer = newRecommendation.find((r) =>
-        r.locations.some((loc) => loc.name === active.id),
+        r.locations.some((loc) => loc.id === active.id),
       );
       const overContainer = newRecommendation.find((r) =>
-        r.locations.some((loc) => loc.name === over.id),
+        r.locations.some((loc) => loc.id === over.id),
       );
 
       if (!activeContainer || !overContainer) return prev;

--- a/frontend/src/types/recommendation.ts
+++ b/frontend/src/types/recommendation.ts
@@ -4,6 +4,7 @@ export interface Recommendation {
 }
 
 export interface Location {
+  id: string;
   name: string;
   description: string;
   imageUrl: string;


### PR DESCRIPTION
## Related Tickets
- #112 

## Summary
- Add new field `id` to each location in the db
- Use `location.id` for dnd id instead of `location.name`

Now, the location with same name will be able to drag and drop without bug

## ❌ Breaking Changes
Old data won't be able to drag and drop anymore and will be showed in gray
<img width="394" alt="image" src="https://github.com/chanon-mike/smart-ryokou/assets/27944646/2c79efe5-4bce-4d81-af00-56330222a0ec">
