### PR TITLE
Distance Matrix for total time consuming

### DIFF
--- a/frontend/locales/en/result.json
+++ b/frontend/locales/en/result.json
@@ -26,5 +26,6 @@
     "shrine-prompt": "Find me a shrine",
     "fun": "Fun",
     "fun-prompt": "Find me something fun"
-  }
+  },
+  "total-duration": "Travel time"
 }

--- a/frontend/locales/ja/result.json
+++ b/frontend/locales/ja/result.json
@@ -26,5 +26,6 @@
     "shrine-prompt": "神社探して",
     "fun": "遊ぶところ",
     "fun-prompt": "遊ぶところ探して"
-  }
+  },
+  "total-duration": "移動時間"
 }

--- a/frontend/src/app/api/service/map/route/distance/getDistanceMatrixData.ts
+++ b/frontend/src/app/api/service/map/route/distance/getDistanceMatrixData.ts
@@ -1,0 +1,46 @@
+import cacheService from '@/service/cache/service';
+import type { DistanceMatrix } from '@/types/distance';
+import axios from 'axios';
+
+export const getDistanceMatrixData = async (
+  originPlaceId: string,
+  destinationPlaceId: string,
+  apiKey: string,
+): Promise<DistanceMatrix> => {
+  try {
+    const cacheKey = `distance:origin${originPlaceId},destination${destinationPlaceId}`;
+    const cachedResult = await cacheService.getKey(cacheKey);
+
+    if (cachedResult !== null) {
+      return JSON.parse(cachedResult);
+    }
+
+    const response = (
+      await axios.get('https://maps.googleapis.com/maps/api/distancematrix/json', {
+        params: {
+          key: apiKey,
+          destination: `place_id:${destinationPlaceId}`,
+          origin: `place_id:${originPlaceId}`,
+          mode: 'driving',
+          language: 'ja',
+        },
+      })
+    ).data;
+
+    const data: DistanceMatrix = {
+      distance: {
+        text: response.rows[0].elements[0].distance.text,
+        value: response.rows[0].elements[0].distance.value,
+      },
+      duration: {
+        text: response.rows[0].elements[0].duration.text,
+        value: response.rows[0].elements[0].duration.value,
+      },
+    };
+    await cacheService.setKey(cacheKey, JSON.stringify(data));
+
+    return data;
+  } catch (error) {
+    throw new Error(`An unexpected error occurred while fetching distance matrix: ${error}`);
+  }
+};

--- a/frontend/src/app/api/service/map/route/distance/getDistanceMatrixData.ts
+++ b/frontend/src/app/api/service/map/route/distance/getDistanceMatrixData.ts
@@ -48,11 +48,32 @@ const getDistanceMatrixFromGoogleMaps = async (
           key: apiKey,
           destinations: `place_id:${destinationPlaceId}`,
           origins: `place_id:${originPlaceId}`,
-          mode: 'driving',
           language: 'ja',
         },
       })
     ).data;
+
+    // In case of place without calculation result (e.g. Shiretoko Peninsula -> Asahikawa)
+    if (response.rows.elements === undefined) {
+      return {
+        rows: [
+          {
+            elements: [
+              {
+                distance: {
+                  text: '不明',
+                  value: 0,
+                },
+                duration: {
+                  text: '不明',
+                  value: 0,
+                },
+              },
+            ],
+          },
+        ],
+      };
+    }
 
     return response;
   } catch (error) {

--- a/frontend/src/app/api/service/map/route/distance/getDistanceMatrixData.ts
+++ b/frontend/src/app/api/service/map/route/distance/getDistanceMatrixData.ts
@@ -19,8 +19,8 @@ export const getDistanceMatrixData = async (
       await axios.get('https://maps.googleapis.com/maps/api/distancematrix/json', {
         params: {
           key: apiKey,
-          destination: `place_id:${destinationPlaceId}`,
-          origin: `place_id:${originPlaceId}`,
+          destinations: `place_id:${destinationPlaceId}`,
+          origins: `place_id:${originPlaceId}`,
           mode: 'driving',
           language: 'ja',
         },

--- a/frontend/src/app/api/service/map/route/distance/route.ts
+++ b/frontend/src/app/api/service/map/route/distance/route.ts
@@ -2,9 +2,16 @@ import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import type { DistanceMatrix } from '@/types/distance';
 import { getDistanceMatrixData } from './getDistanceMatrixData';
+import { GOOGLE_MAPS_API_KEY } from '@/libs/envValues';
 
-export async function POST(req: NextRequest) {
-  const { originPlaceId, destinationPlaceId, apiKey } = await req.json();
+export async function GET(req: NextRequest) {
+  const originPlaceId = req.nextUrl.searchParams.get('originPlaceId');
+  const destinationPlaceId = req.nextUrl.searchParams.get('destinationPlaceId');
+  const apiKey = GOOGLE_MAPS_API_KEY;
+
+  if (!originPlaceId || !destinationPlaceId) {
+    return NextResponse.json({ error: 'Missing required parameters' }, { status: 400 });
+  }
 
   try {
     const response: DistanceMatrix = await getDistanceMatrixData(

--- a/frontend/src/app/api/service/map/route/distance/route.ts
+++ b/frontend/src/app/api/service/map/route/distance/route.ts
@@ -23,6 +23,6 @@ export async function GET(req: NextRequest) {
     return NextResponse.json(response);
   } catch (error) {
     console.error(error);
-    return NextResponse.json({ error: `Error: ${error}` }, { status: 400 });
+    return NextResponse.json({ error }, { status: 400 });
   }
 }

--- a/frontend/src/app/api/service/map/route/distance/route.ts
+++ b/frontend/src/app/api/service/map/route/distance/route.ts
@@ -1,0 +1,21 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import type { DistanceMatrix } from '@/types/distance';
+import { getDistanceMatrixData } from './getDistanceMatrixData';
+
+export async function POST(req: NextRequest) {
+  const { originPlaceId, destinationPlaceId, apiKey } = await req.json();
+
+  try {
+    const response: DistanceMatrix = await getDistanceMatrixData(
+      originPlaceId,
+      destinationPlaceId,
+      apiKey,
+    );
+
+    return NextResponse.json(response);
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: `Error: ${error}` }, { status: 400 });
+  }
+}

--- a/frontend/src/client/Client.ts
+++ b/frontend/src/client/Client.ts
@@ -2,11 +2,13 @@ import type { ClientInterface } from './ClientInterface';
 import getResult from './api/get-result/implement';
 import getLocation from './api/get-new-location/implement';
 import { getRestaurant } from './api/get-restaurant/implement';
+import { getDistanceMatrix } from './api/get-distance-matrix/implement';
 
 const Client: ClientInterface = {
   getResult,
   getLocation,
   getRestaurant,
+  getDistanceMatrix,
 };
 
 export default Client;

--- a/frontend/src/client/ClientInterface.ts
+++ b/frontend/src/client/ClientInterface.ts
@@ -1,9 +1,11 @@
 import type { GetResultInterface } from './api/get-result/interface';
 import type { GetNewLocationInterface } from './api/get-new-location/interface';
 import type { GetRestaurantInterface } from './api/get-restaurant/interface';
+import type { GetDistanceMatrixInterface } from './api/get-distance-matrix/interface';
 
 export interface ClientInterface {
   getResult: GetResultInterface;
   getLocation: GetNewLocationInterface;
   getRestaurant: GetRestaurantInterface;
+  getDistanceMatrix: GetDistanceMatrixInterface;
 }

--- a/frontend/src/client/api/get-distance-matrix/implement.ts
+++ b/frontend/src/client/api/get-distance-matrix/implement.ts
@@ -1,0 +1,21 @@
+import type { ApiContext } from '@/client/ApiContext';
+import type { GetDistanceMatrixRequest, GetDistanceMatrixResponse } from './interface';
+import mapRouteService from '@/service/map/route/service';
+
+export const getDistanceMatrix = async (context: ApiContext, request: GetDistanceMatrixRequest) => {
+  if (context.requireAuth && !context.isAuth) {
+    throw new Error('User unauthorized');
+  }
+
+  try {
+    const response: GetDistanceMatrixResponse = await mapRouteService.getDistanceMatrix(
+      request.originPlaceId,
+      request.destinationPlaceId,
+    );
+
+    return response;
+  } catch (error) {
+    console.log(error);
+    throw error;
+  }
+};

--- a/frontend/src/client/api/get-distance-matrix/interface.ts
+++ b/frontend/src/client/api/get-distance-matrix/interface.ts
@@ -1,0 +1,14 @@
+import type { ApiContext } from '../../ApiContext';
+import type { DistanceMatrix } from '@/types/distance';
+
+export type GetDistanceMatrixInterface = (
+  context: ApiContext,
+  request: GetDistanceMatrixRequest,
+) => Promise<GetDistanceMatrixResponse>;
+
+export interface GetDistanceMatrixRequest {
+  originPlaceId: string;
+  destinationPlaceId: string;
+}
+
+export type GetDistanceMatrixResponse = DistanceMatrix;

--- a/frontend/src/components/recommendation/list/DroppableDateList.tsx
+++ b/frontend/src/components/recommendation/list/DroppableDateList.tsx
@@ -3,12 +3,16 @@
 import SortableLocationCard from '@/components/recommendation/list/SortableLocationCard';
 import type { Location, Recommendation } from '@/types/recommendation';
 import { SortableContext, rectSortingStrategy } from '@dnd-kit/sortable';
-import { Box, Typography } from '@mui/material';
+import { Box, Skeleton, Typography } from '@mui/material';
 import type { FC } from 'react';
 import { useContext } from 'react';
 import { ActiveLocationContext } from '@/components/recommendation/ActiveLocationContext';
 import { SecondaryColorHoverIconButton } from '@/components/common/mui/SecondaryColorHoverIconButton';
 import PinDropIcon from '@mui/icons-material/PinDrop';
+import { useDistanceMatrix } from '@/components/recommendation/list/useDistanceMatrix';
+import DistanceMatrixStep from '@/components/recommendation/list/distance-matrix/DistanceMatrixStep';
+import TotalDuration from '@/components/recommendation/list/distance-matrix/TotalDuration';
+
 interface DroppableDateListProps {
   recIndex: number;
   recommendation: Recommendation;
@@ -25,6 +29,8 @@ const DroppableDateList: FC<DroppableDateListProps> = ({
   const activeLocationContext = useContext(ActiveLocationContext);
   const { setActiveLocation, setActiveStep, setActiveDate, setMapCenter, setZoom } =
     activeLocationContext;
+  const { distanceMatrix, isLoadingDistanceMatrix, totalDistanceMatrix } =
+    useDistanceMatrix(recommendation);
 
   const handleSelect = (index: number) => {
     setActiveLocation(recommendation.locations[index]);
@@ -58,78 +64,62 @@ const DroppableDateList: FC<DroppableDateListProps> = ({
       items={recommendation.locations.map((loc) => loc.id)}
       strategy={rectSortingStrategy}
     >
-      <Box sx={{ display: 'flex', flexDirection: 'row', marginTop: 1 }}>
+      <Box sx={{ display: 'flex', flexDirection: 'row', alignItems: 'center', flexGrow: 1 }}>
         <Typography variant="h6" sx={{ marginTop: 1 }}>
           {recommendation.date}
         </Typography>
         <SecondaryColorHoverIconButton onClick={handleSelectDate} sx={{ paddingBottom: 0 }}>
           <PinDropIcon />
         </SecondaryColorHoverIconButton>
+        <TotalDuration
+          isLoadingDistanceMatrix={isLoadingDistanceMatrix}
+          totalDistanceMatrix={totalDistanceMatrix}
+        />
       </Box>
 
       <Box sx={{ marginTop: 1 }}>
-        {recommendation.locations.map((loc, index) => (
-          <div key={`${loc}${index}`}>
-            {recommendation.locations.length === 1 ? (
-              <SortableLocationCard
-                location={loc}
-                disabled={true}
-                index={index}
-                recIndex={recIndex}
-                onSelect={handleSelect}
-                onConfirmDelete={onConfirmDeleteCard}
-                onFindRestaurant={onFindRestaurant}
-              />
-            ) : (
-              <SortableLocationCard
-                location={loc}
-                index={index}
-                recIndex={recIndex}
-                onSelect={handleSelect}
-                onConfirmDelete={onConfirmDeleteCard}
-                onFindRestaurant={onFindRestaurant}
-              />
-            )}
-          </div>
-        ))}
-      </Box>
-      {/* TODO: Refactor stepper when implement the travel duration */}
-      {/* <Stepper activeStep={activeStep} orientation="vertical" style={{ minHeight: '100px' }}>
-        {recommendation.locations.map((step, index) => (
-          <Step key={step.name} active={true}>
-            <StepLabel
-              StepIconComponent={(props) => (
-                <StepIcon
-                  {...props}
-                  icon={props.icon}
-                  active={props.active || props.completed}
-                  completed={false}
-                />
-              )}
-            >
-              <Typography variant="body1">{step.name}</Typography>
-            </StepLabel>
-            <StepContent>
-              {recommendation.locations.length === 1 ? (
+        {recommendation.locations.map((loc, index) => {
+          const locationsLength = recommendation.locations.length;
+
+          return (
+            <div key={`${loc}${index}`}>
+              {locationsLength === 1 ? (
                 <SortableLocationCard
-                  step={step}
+                  location={loc}
                   disabled={true}
                   index={index}
+                  recIndex={recIndex}
                   onSelect={handleSelect}
                   onConfirmDelete={onConfirmDeleteCard}
+                  onFindRestaurant={onFindRestaurant}
                 />
               ) : (
-                <SortableLocationCard
-                  step={step}
-                  index={index}
-                  onSelect={handleSelect}
-                  onConfirmDelete={onConfirmDeleteCard}
-                />
+                <>
+                  <SortableLocationCard
+                    location={loc}
+                    index={index}
+                    recIndex={recIndex}
+                    onSelect={handleSelect}
+                    onConfirmDelete={onConfirmDeleteCard}
+                    onFindRestaurant={onFindRestaurant}
+                  />
+                  {/* Distance and Duration with loading skeleton */}
+                  {index < locationsLength - 1 &&
+                    (!isLoadingDistanceMatrix ? (
+                      <DistanceMatrixStep
+                        key={recommendation.locations[index].id}
+                        distance={distanceMatrix[index]?.distance.text}
+                        duration={distanceMatrix[index]?.duration.text}
+                      />
+                    ) : (
+                      <Skeleton variant="text" sx={{ fontSize: '1rem' }} />
+                    ))}
+                </>
               )}
-            </StepContent>
-          </Step>
-        ))}
-      </Stepper> */}
+            </div>
+          );
+        })}
+      </Box>
     </SortableContext>
   );
 };

--- a/frontend/src/components/recommendation/list/DroppableDateList.tsx
+++ b/frontend/src/components/recommendation/list/DroppableDateList.tsx
@@ -3,7 +3,7 @@
 import SortableLocationCard from '@/components/recommendation/list/SortableLocationCard';
 import type { Location, Recommendation } from '@/types/recommendation';
 import { SortableContext, rectSortingStrategy } from '@dnd-kit/sortable';
-import { Box, Skeleton, Typography } from '@mui/material';
+import { Box, Paper, Skeleton, Typography } from '@mui/material';
 import type { FC } from 'react';
 import { useContext } from 'react';
 import { ActiveLocationContext } from '@/components/recommendation/ActiveLocationContext';
@@ -64,18 +64,25 @@ const DroppableDateList: FC<DroppableDateListProps> = ({
       items={recommendation.locations.map((loc) => loc.id)}
       strategy={rectSortingStrategy}
     >
-      <Box sx={{ display: 'flex', flexDirection: 'row', alignItems: 'center', flexGrow: 1 }}>
-        <Typography variant="h6" sx={{ marginTop: 1 }}>
-          {recommendation.date}
-        </Typography>
-        <SecondaryColorHoverIconButton onClick={handleSelectDate} sx={{ paddingBottom: 0 }}>
+      <Paper
+        sx={{
+          display: 'flex',
+          flexDirection: 'row',
+          alignItems: 'center',
+          p: 1,
+          marginTop: { sm: 0, xs: 1 },
+        }}
+        variant="outlined"
+      >
+        <Typography variant="subtitle1">{recommendation.date}</Typography>
+        <SecondaryColorHoverIconButton onClick={handleSelectDate} sx={{ alignItems: 'center' }}>
           <PinDropIcon />
         </SecondaryColorHoverIconButton>
         <TotalDuration
           isLoadingDistanceMatrix={isLoadingDistanceMatrix}
           totalDistanceMatrix={totalDistanceMatrix}
         />
-      </Box>
+      </Paper>
 
       <Box sx={{ marginTop: 1 }}>
         {recommendation.locations.map((loc, index) => {

--- a/frontend/src/components/recommendation/list/DroppableDateList.tsx
+++ b/frontend/src/components/recommendation/list/DroppableDateList.tsx
@@ -29,8 +29,7 @@ const DroppableDateList: FC<DroppableDateListProps> = ({
   const activeLocationContext = useContext(ActiveLocationContext);
   const { setActiveLocation, setActiveStep, setActiveDate, setMapCenter, setZoom } =
     activeLocationContext;
-  const { distanceMatrix, isLoadingDistanceMatrix, totalDistanceMatrix } =
-    useDistanceMatrix(recommendation);
+  const { distanceMatrix, isLoadingDistanceMatrix } = useDistanceMatrix(recommendation);
 
   const handleSelect = (index: number) => {
     setActiveLocation(recommendation.locations[index]);
@@ -80,7 +79,7 @@ const DroppableDateList: FC<DroppableDateListProps> = ({
         </SecondaryColorHoverIconButton>
         <TotalDuration
           isLoadingDistanceMatrix={isLoadingDistanceMatrix}
-          totalDistanceMatrix={totalDistanceMatrix}
+          distanceMatrix={distanceMatrix}
         />
       </Paper>
 
@@ -115,8 +114,8 @@ const DroppableDateList: FC<DroppableDateListProps> = ({
                     (!isLoadingDistanceMatrix ? (
                       <DistanceMatrixStep
                         key={recommendation.locations[index].id}
-                        distance={distanceMatrix[index]?.distance.text}
-                        duration={distanceMatrix[index]?.duration.text}
+                        distance={distanceMatrix[index]?.distance?.text}
+                        duration={distanceMatrix[index]?.duration?.text}
                       />
                     ) : (
                       <Skeleton variant="text" sx={{ fontSize: '1rem' }} />

--- a/frontend/src/components/recommendation/list/RecommendationContainer.tsx
+++ b/frontend/src/components/recommendation/list/RecommendationContainer.tsx
@@ -74,7 +74,7 @@ const RecommendationContainer = () => {
         collisionDetection={closestCorners}
         modifiers={[restrictToVerticalAxis]}
       >
-        <Box style={{ maxWidth: '400px', height: '75vh', overflowY: 'auto', paddingRight: '20px' }}>
+        <Box style={{ height: '75vh', overflowY: 'auto', paddingRight: '20px' }}>
           {session.recommendations.map((r, index) => (
             <Box key={`${r.date}-${index}`}>
               <DroppableDateList

--- a/frontend/src/components/recommendation/list/distance-matrix/DistanceMatrixStep.tsx
+++ b/frontend/src/components/recommendation/list/distance-matrix/DistanceMatrixStep.tsx
@@ -8,14 +8,23 @@ type DistanceMatrixStepProps = {
 };
 
 const DistanceMatrixStep = ({ distance, duration }: DistanceMatrixStepProps) => {
+  // TODO: Change to warning color when distance is unknown
+  const colorIsNotAvailable = distance === '不明' || duration === '不明';
+  const textColorIfisNotAvailable = colorIsNotAvailable ? 'warning.main' : 'inherit';
+  const colorIfisNotAvailable = colorIsNotAvailable ? 'warning' : 'inherit';
+
   return (
     <Box
       sx={{ display: 'flex', flexDirection: 'row', justifyContent: 'center', alignItems: 'center' }}
     >
-      <Typography variant="caption">{distance}</Typography>
-      <KeyboardArrowDownIcon />
-      <Typography variant="caption">{duration}</Typography>
-      <DirectionsCarIcon fontSize="small" />
+      <Typography variant="caption" color={textColorIfisNotAvailable}>
+        {distance}
+      </Typography>
+      <KeyboardArrowDownIcon color={colorIfisNotAvailable} />
+      <Typography variant="caption" color={textColorIfisNotAvailable}>
+        {duration}
+      </Typography>
+      <DirectionsCarIcon fontSize="small" color={colorIfisNotAvailable} />
     </Box>
   );
 };

--- a/frontend/src/components/recommendation/list/distance-matrix/DistanceMatrixStep.tsx
+++ b/frontend/src/components/recommendation/list/distance-matrix/DistanceMatrixStep.tsx
@@ -1,0 +1,23 @@
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import DirectionsCarIcon from '@mui/icons-material/DirectionsCar';
+import { Box, Typography } from '@mui/material';
+
+type DistanceMatrixStepProps = {
+  distance: string;
+  duration: string;
+};
+
+const DistanceMatrixStep = ({ distance, duration }: DistanceMatrixStepProps) => {
+  return (
+    <Box
+      sx={{ display: 'flex', flexDirection: 'row', justifyContent: 'center', alignItems: 'center' }}
+    >
+      <Typography variant="caption">{distance}</Typography>
+      <KeyboardArrowDownIcon />
+      <Typography variant="caption">{duration}</Typography>
+      <DirectionsCarIcon fontSize="small" />
+    </Box>
+  );
+};
+
+export default DistanceMatrixStep;

--- a/frontend/src/components/recommendation/list/distance-matrix/TotalDuration.tsx
+++ b/frontend/src/components/recommendation/list/distance-matrix/TotalDuration.tsx
@@ -25,8 +25,7 @@ const TotalDuration = ({ isLoadingDistanceMatrix, totalDistanceMatrix }: TotalDu
           flexDirection: 'row',
           marginLeft: 'auto',
           alignItems: 'center',
-          marginTop: 1,
-          gap: 1,
+          gap: 0.5,
         }}
       >
         <TimerIcon fontSize="small" color="action" />

--- a/frontend/src/components/recommendation/list/distance-matrix/TotalDuration.tsx
+++ b/frontend/src/components/recommendation/list/distance-matrix/TotalDuration.tsx
@@ -1,0 +1,39 @@
+import TimerIcon from '@mui/icons-material/Timer';
+import { Box, Skeleton, Tooltip, Typography } from '@mui/material';
+import moment from 'moment';
+
+type TotalDurationProps = {
+  totalDistanceMatrix: {
+    distance: number;
+    duration: number;
+  };
+  isLoadingDistanceMatrix: boolean;
+};
+
+const TotalDuration = ({ isLoadingDistanceMatrix, totalDistanceMatrix }: TotalDurationProps) => {
+  const totalDuration = moment.utc(1000 * totalDistanceMatrix.duration).format('H[h] mm[m]');
+
+  if (isLoadingDistanceMatrix) {
+    return <Skeleton variant="text" sx={{ marginLeft: 'auto', width: '10%' }} />;
+  }
+
+  return (
+    <Tooltip disableFocusListener disableTouchListener title="移動時間" placement="top">
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'row',
+          marginLeft: 'auto',
+          alignItems: 'center',
+          marginTop: 1,
+          gap: 1,
+        }}
+      >
+        <TimerIcon fontSize="small" color="action" />
+        <Typography variant="subtitle1">{totalDuration}</Typography>
+      </Box>
+    </Tooltip>
+  );
+};
+
+export default TotalDuration;

--- a/frontend/src/components/recommendation/list/distance-matrix/TotalDuration.tsx
+++ b/frontend/src/components/recommendation/list/distance-matrix/TotalDuration.tsx
@@ -26,6 +26,7 @@ const TotalDuration = ({ isLoadingDistanceMatrix, totalDistanceMatrix }: TotalDu
           marginLeft: 'auto',
           alignItems: 'center',
           gap: 0.5,
+          cursor: 'default',
         }}
       >
         <TimerIcon fontSize="small" color="action" />

--- a/frontend/src/components/recommendation/list/distance-matrix/TotalDuration.tsx
+++ b/frontend/src/components/recommendation/list/distance-matrix/TotalDuration.tsx
@@ -1,21 +1,26 @@
+import type { DistanceMatrix } from '@/types/distance';
 import TimerIcon from '@mui/icons-material/Timer';
 import { Box, Skeleton, Tooltip, Typography } from '@mui/material';
 import moment from 'moment';
 
 type TotalDurationProps = {
-  totalDistanceMatrix: {
-    distance: number;
-    duration: number;
-  };
+  distanceMatrix: DistanceMatrix[];
   isLoadingDistanceMatrix: boolean;
 };
 
-const TotalDuration = ({ isLoadingDistanceMatrix, totalDistanceMatrix }: TotalDurationProps) => {
-  const totalDuration = moment.utc(1000 * totalDistanceMatrix.duration).format('H[h] mm[m]');
-
+const TotalDuration = ({ isLoadingDistanceMatrix, distanceMatrix }: TotalDurationProps) => {
   if (isLoadingDistanceMatrix) {
     return <Skeleton variant="text" sx={{ marginLeft: 'auto', width: '10%' }} />;
   }
+
+  // const totalDuration = moment.utc(1000 * totalDistanceMatrix.duration).format('H[h] mm[m]');
+  const totalDuration = moment
+    .utc(
+      distanceMatrix.reduce((acc, curr) => {
+        return acc + curr.duration.value;
+      }, 0) * 1000,
+    )
+    .format('H[h] mm[m]');
 
   return (
     <Tooltip disableFocusListener disableTouchListener title="移動時間" placement="top">

--- a/frontend/src/components/recommendation/list/useDistanceMatrix.tsx
+++ b/frontend/src/components/recommendation/list/useDistanceMatrix.tsx
@@ -2,7 +2,7 @@ import Client from '@/client/Client';
 import { useSnackbar } from '@/components/common/snackbar/SnackbarContext';
 import type { DistanceMatrix } from '@/types/distance';
 import type { Recommendation } from '@/types/recommendation';
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect } from 'react';
 
 export const useDistanceMatrix = (recommendation: Recommendation) => {
   const [distanceMatrix, setDistanceMatrix] = useState<DistanceMatrix[]>([]);
@@ -52,17 +52,5 @@ export const useDistanceMatrix = (recommendation: Recommendation) => {
     // So we need to stringify the object to make it work
   }, [openSnackbar, recommendation.locations, stringifiedRecommendation]);
 
-  const totalDistanceMatrix = useMemo(
-    () => ({
-      distance: distanceMatrix.reduce((acc, curr) => {
-        return acc + curr.distance.value;
-      }, 0),
-      duration: distanceMatrix.reduce((acc, curr) => {
-        return acc + curr.duration.value;
-      }, 0),
-    }),
-    [distanceMatrix],
-  );
-
-  return { distanceMatrix, isLoadingDistanceMatrix, totalDistanceMatrix };
+  return { distanceMatrix, isLoadingDistanceMatrix };
 };

--- a/frontend/src/components/recommendation/list/useDistanceMatrix.tsx
+++ b/frontend/src/components/recommendation/list/useDistanceMatrix.tsx
@@ -1,0 +1,68 @@
+import Client from '@/client/Client';
+import { useSnackbar } from '@/components/common/snackbar/SnackbarContext';
+import type { DistanceMatrix } from '@/types/distance';
+import type { Recommendation } from '@/types/recommendation';
+import { useState, useEffect, useMemo } from 'react';
+
+export const useDistanceMatrix = (recommendation: Recommendation) => {
+  const [distanceMatrix, setDistanceMatrix] = useState<DistanceMatrix[]>([]);
+  const [isLoadingDistanceMatrix, setIsLoadingDistanceMatrix] = useState<boolean>(false);
+  const { openSnackbar } = useSnackbar();
+
+  const stringifiedRecommendation = JSON.stringify(recommendation);
+
+  useEffect(() => {
+    const fetchDistanceMatrix = async () => {
+      setIsLoadingDistanceMatrix(true);
+      const distanceMatrixPromises = [];
+
+      // Fetches distance matrix for each pair of locations in the recommendation.
+      for (let i = 0; i < recommendation.locations.length - 1; i++) {
+        if (!recommendation.locations[i].placeId) {
+          return;
+        }
+
+        const promise = Client.getDistanceMatrix(
+          {
+            useMock: false,
+            requireAuth: false,
+          },
+          {
+            originPlaceId: recommendation.locations[i].placeId,
+            destinationPlaceId: recommendation.locations[i + 1].placeId,
+          },
+        );
+        distanceMatrixPromises.push(promise);
+      }
+
+      // Sets the distance matrix state after all the promises are resolved.
+      Promise.all(distanceMatrixPromises)
+        .then((responses) => setDistanceMatrix(responses))
+        .catch((error) => {
+          console.error('Error fetching distance matrix:', error);
+          if (error instanceof Error) {
+            openSnackbar(error.message, 'error');
+          }
+        })
+        .finally(() => setIsLoadingDistanceMatrix(false));
+    };
+
+    fetchDistanceMatrix();
+    // useEffect wont' see the changes if you changing properties of the object but not the object itself
+    // So we need to stringify the object to make it work
+  }, [openSnackbar, recommendation.locations, stringifiedRecommendation]);
+
+  const totalDistanceMatrix = useMemo(
+    () => ({
+      distance: distanceMatrix.reduce((acc, curr) => {
+        return acc + curr.distance.value;
+      }, 0),
+      duration: distanceMatrix.reduce((acc, curr) => {
+        return acc + curr.duration.value;
+      }, 0),
+    }),
+    [distanceMatrix],
+  );
+
+  return { distanceMatrix, isLoadingDistanceMatrix, totalDistanceMatrix };
+};

--- a/frontend/src/service/map/route/interface.ts
+++ b/frontend/src/service/map/route/interface.ts
@@ -1,0 +1,5 @@
+import type { DistanceMatrix } from '@/types/distance';
+
+export interface MapRouteServiceInterface {
+  getDistanceMatrix: (originPlaceId: string, destinationPlaceId: string) => Promise<DistanceMatrix>;
+}

--- a/frontend/src/service/map/route/service.ts
+++ b/frontend/src/service/map/route/service.ts
@@ -1,0 +1,33 @@
+import type { MapRouteServiceInterface } from './interface';
+import { GOOGLE_MAPS_API_KEY } from '@/libs/envValues';
+import type { DistanceMatrix } from '@/types/distance';
+
+class MapRouteService implements MapRouteServiceInterface {
+  private apiKey: string;
+
+  constructor(apiKey: string) {
+    this.apiKey = apiKey;
+  }
+
+  async getDistanceMatrix(
+    originPlaceId: string,
+    destinationPlaceId: string,
+  ): Promise<DistanceMatrix> {
+    const params = {
+      key: this.apiKey,
+      destination: `place_id:${destinationPlaceId}`,
+      origin: `place_id:${originPlaceId}`,
+    };
+    const query = new URLSearchParams(params);
+
+    const placeData = await fetch(encodeURI(`/api/service/map/route/distance?${query}`), {
+      method: 'GET',
+    }).then((response) => response.json());
+
+    return placeData;
+  }
+}
+
+const mapRouteService = new MapRouteService(GOOGLE_MAPS_API_KEY);
+
+export default mapRouteService;

--- a/frontend/src/service/map/route/service.ts
+++ b/frontend/src/service/map/route/service.ts
@@ -1,33 +1,25 @@
 import type { MapRouteServiceInterface } from './interface';
-import { GOOGLE_MAPS_API_KEY } from '@/libs/envValues';
 import type { DistanceMatrix } from '@/types/distance';
 
 class MapRouteService implements MapRouteServiceInterface {
-  private apiKey: string;
-
-  constructor(apiKey: string) {
-    this.apiKey = apiKey;
-  }
-
   async getDistanceMatrix(
     originPlaceId: string,
     destinationPlaceId: string,
   ): Promise<DistanceMatrix> {
     const params = {
-      key: this.apiKey,
-      destination: `place_id:${destinationPlaceId}`,
-      origin: `place_id:${originPlaceId}`,
+      destinationPlaceId,
+      originPlaceId,
     };
     const query = new URLSearchParams(params);
 
-    const placeData = await fetch(encodeURI(`/api/service/map/route/distance?${query}`), {
+    const distanceMatrixData = await fetch(encodeURI(`/api/service/map/route/distance?${query}`), {
       method: 'GET',
     }).then((response) => response.json());
 
-    return placeData;
+    return distanceMatrixData;
   }
 }
 
-const mapRouteService = new MapRouteService(GOOGLE_MAPS_API_KEY);
+const mapRouteService = new MapRouteService();
 
 export default mapRouteService;

--- a/frontend/src/types/distance.ts
+++ b/frontend/src/types/distance.ts
@@ -1,0 +1,10 @@
+export interface DistanceMatrix {
+  distance: {
+    text: string;
+    value: number;
+  };
+  duration: {
+    text: string;
+    value: number;
+  };
+}


### PR DESCRIPTION
## Background
- From user feedback and sensei feedback, we want to have the total time consuming for each place
- #149 
- #148 

## Summary
- Update UI for each date and timer
- Add duration time for each location
- **Due to the API limitation, Google Direction API don't support Japan transit**

## Screenshot
<img width="1435" alt="image" src="https://github.com/chanon-mike/smart-ryokou/assets/27944646/c63e5e8e-fd4c-4fc7-9853-d336b8da5aaa">
